### PR TITLE
add customized responses feature

### DIFF
--- a/device/ensto/device_ensto.py
+++ b/device/ensto/device_ensto.py
@@ -419,6 +419,7 @@ What should I do? (enter the number + enter)
 0: Back
 1: HeartBeat
 2: StatusUpdate
+98: """ + ("Disable" if self.customized_responses else "Enable") + """ Customized Responses
 99: Full Custom
 """)
             if input1 == "0":
@@ -432,4 +433,6 @@ What should I do? (enter the number + enter)
                 input1 = await aioconsole.ainput("Enter full raw request:\n")
                 req_json = self.__raw_to_json(input1)
                 await self.by_device_req_send(req_json['id'], req_json)
+            elif input1 == "98":
+                self.customized_responses = not self.customized_responses
         pass

--- a/device/ocpp_j/device_ocpp_j.py
+++ b/device/ocpp_j/device_ocpp_j.py
@@ -352,9 +352,11 @@ class DeviceOcppJ(DeviceAbstract):
 
     async def by_middleware_req(self, req_id: str, req_action: str, req_payload: typing.Any):
         resp_payload = None
+        customized_response_configured = False
         if self.customized_responses and req_action in map(lambda x: x["name"].lower(), self.response_payloads):
             customized_response = next(x for x in self.response_payloads if x["name"].lower() == req_action)
             resp_payload = customized_response["response"]
+            customized_response_configured = True
             self.response_payloads.remove(customized_response)
         elif req_action in map(lambda x: str(x).lower(), [
             "ClearCache",
@@ -388,45 +390,46 @@ class DeviceOcppJ(DeviceAbstract):
             }
 
         if req_action == "TriggerMessage".lower():
-            if req_payload["requestedMessage"] == "MeterValues":
-                options = {
-                    "connectorId": req_payload["connectorId"] if "connectorId" in req_payload else 0,
-                }
-                resp_payload = {
-                    "status": "Accepted"
-                }
-                await self.by_middleware_req_response_ready(req_id, resp_payload);
-                await self.action_meter_value(**options)
-                return
-            if req_payload["requestedMessage"] == "BootNotification":
-                resp_payload = {
-                    "status": "Accepted"
-                }
-                await self.by_middleware_req_response_ready(req_id, resp_payload);
-                await self.action_register()
-                return
-            if req_payload["requestedMessage"] == "Heartbeat":
-                resp_payload = {
-                    "status": "Accepted"
-                }
-                await self.by_middleware_req_response_ready(req_id, resp_payload);
-                await self.action_heart_beat()
-                return
-            if req_payload["requestedMessage"] == "StatusNotification":
-                options = {
-                    "connectorId": req_payload["connectorId"] if "connectorId" in req_payload else 0,
-                }
-                resp_payload = {
-                    "status": "Accepted"
-                }
-                await self.by_middleware_req_response_ready(req_id, resp_payload);
-                if self.charge_in_progress:
-                    await self.action_status_update("Charging",**options)
-                else:
-                    await self.action_status_update("Available",**options)
-                return
-        if not self.customized_responses and req_action == "RemoteStartTransaction".lower():
-            if not self.charge_can_start():
+            if (customized_response_configured and resp_payload["status"] == "Accepted") or (not customized_response_configured):
+                if req_payload["requestedMessage"] == "MeterValues":
+                    options = {
+                        "connectorId": req_payload["connectorId"] if "connectorId" in req_payload else 0,
+                    }
+                    resp_payload = {
+                        "status": "Accepted"
+                    }
+                    await self.by_middleware_req_response_ready(req_id, resp_payload);
+                    await self.action_meter_value(**options)
+                    return
+                if req_payload["requestedMessage"] == "BootNotification":
+                    resp_payload = {
+                        "status": "Accepted"
+                    }
+                    await self.by_middleware_req_response_ready(req_id, resp_payload);
+                    await self.action_register()
+                    return
+                if req_payload["requestedMessage"] == "Heartbeat":
+                    resp_payload = {
+                        "status": "Accepted"
+                    }
+                    await self.by_middleware_req_response_ready(req_id, resp_payload);
+                    await self.action_heart_beat()
+                    return
+                if req_payload["requestedMessage"] == "StatusNotification":
+                    options = {
+                        "connectorId": req_payload["connectorId"] if "connectorId" in req_payload else 0,
+                    }
+                    resp_payload = {
+                        "status": "Accepted"
+                    }
+                    await self.by_middleware_req_response_ready(req_id, resp_payload);
+                    if self.charge_in_progress:
+                        await self.action_status_update("Charging",**options)
+                    else:
+                        await self.action_status_update("Available",**options)
+                    return
+        if ((customized_response_configured and resp_payload["status"] == "Accepted") or not customized_response_configured) and req_action == "RemoteStartTransaction".lower():
+            if not self.charge_can_start() and not customized_response_configured:
                 resp_payload["status"] = "Rejected"
             else:
                 options = {
@@ -436,8 +439,8 @@ class DeviceOcppJ(DeviceAbstract):
                 self.logger.info(f"Device, Read, Request, RemoteStart, Options: {json.dumps(options)}")
                 asyncio.create_task(utility.run_with_delay(self.flow_charge(False, **options), 2))
 
-        if not self.customized_responses and req_action == "RemoteStopTransaction".lower():
-            if not self.charge_can_stop(req_payload["transactionId"] if "transactionId" in req_payload else 0):
+        if ((customized_response_configured and resp_payload["status"] == "Accepted") or not customized_response_configured) and req_action == "RemoteStopTransaction".lower():
+            if not self.charge_can_stop(req_payload["transactionId"] if "transactionId" in req_payload else 0) and not customized_response_configured:
                 resp_payload["status"] = "Rejected"
             else:
                 asyncio.create_task(utility.run_with_delay(self.flow_charge_stop(), 2))

--- a/device/ocpp_s/device_ocpp_s.py
+++ b/device/ocpp_s/device_ocpp_s.py
@@ -388,6 +388,7 @@ What should I do? (enter the number + enter)
 0: Back
 1: HeartBeat
 2: StatusUpdate
+98: """ + ("Disable" if self.customized_responses else "Enable") + """ Customized Responses
 99: Full custom
 """)
             if input1 == "0":
@@ -405,4 +406,6 @@ What should I do? (enter the number + enter)
                 input_action = await aioconsole.ainput("Enter full custom action name:\n")
                 input_payload = await aioconsole.ainput("Enter full custom payload:\n")
                 await self.by_device_req_send_raw(json.loads(input_payload), input_action)
+            elif input1 == "98":
+                self.customized_responses = not self.customized_responses
         pass

--- a/how-to-use/config.yaml
+++ b/how-to-use/config.yaml
@@ -39,7 +39,28 @@ devices:
     spec_imsi: 5678 # OCPP-J property
     spec_meterType: MeterType_X # OCPP-J property
     spec_meterSerialNumber: NO_ID # OCPP-J property
-
+    response_payloads: # customized responsed per request
+      - name: GetConfiguration
+        response:
+          configurationKey:
+          - key: CreditCardEnergyTariff
+            value: '0,0'
+            readonly: 'false'
+          - key: CreditCardTimeTariff
+            value: '1,0'
+            readonly: 'false'
+          - key: CreditCardCurrency
+            value: EUR
+            readonly: 'false'
+      - name: ChangeConfiguration
+        response:
+          status: Accepted
+      - name: ChangeConfiguration
+        response:
+          status: Accepted
+      - name: Reset
+        response:
+          status: Accepted
   - type: ensto
     name: test-ensto-1
     server_host: "sample-server.com" # Sample Server
@@ -51,3 +72,13 @@ devices:
     spec_vendor: Vendor_X
     spec_model: Model_X
     spec_sw: SW_X
+    response_payloads: # customized responsed per request
+      - name: 14
+        response:
+          upd: 1
+      - name: 42
+        response:
+          ack: 1
+      - name: 42
+        response:
+          nack: 1

--- a/runtime/config_parser.py
+++ b/runtime/config_parser.py
@@ -53,9 +53,6 @@ class ConfigParser:
                 dev1.spec_meterType = config['spec_meterType']
             if 'spec_meterSerialNumber' in config:
                 dev1.spec_meterSerialNumber = config['spec_meterSerialNumber']
-            if 'response_payloads' in config:
-                dev1.customized_responses = True
-                dev1.response_payloads = config['response_payloads']
             result = dev1
         if config['type'] == 'ocpp-s':
             dev1 = device.DeviceOcppS(config['spec_identifier'])
@@ -106,5 +103,7 @@ class ConfigParser:
             result.error_exit = config['error_exit']
         if 'response_timeout_seconds' in config:
             result.response_timeout_seconds = config['response_timeout_seconds']
-
+        if 'response_payloads' in config:
+            result.customized_responses = True
+            result.response_payloads = config['response_payloads']
         return result

--- a/runtime/config_parser.py
+++ b/runtime/config_parser.py
@@ -53,6 +53,9 @@ class ConfigParser:
                 dev1.spec_meterType = config['spec_meterType']
             if 'spec_meterSerialNumber' in config:
                 dev1.spec_meterSerialNumber = config['spec_meterSerialNumber']
+            if 'response_payloads' in config:
+                dev1.customized_responses = True
+                dev1.response_payloads = config['response_payloads']
             result = dev1
         if config['type'] == 'ocpp-s':
             dev1 = device.DeviceOcppS(config['spec_identifier'])


### PR DESCRIPTION
This MR will add customized response feature to ocpp-j, ocpp-s and ensto devices. you can define what response should be replied on every request. this is good when you want to examine your retry behaviour by setting the first response to be rejected and the second response to be accepted

Also this feature can be enable/disbale in the menu