### PR TITLE
Fix SSL context for wss connection using certifi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ coloredlogs
 aioconsole
 pyyaml
 zeep[async]
+certifi


### PR DESCRIPTION
This PR fixes SSL certificate verification errors encountered when connecting to wss:// URLs in the device simulator on some local environments, especially on macOS.

**Background:**
While wss connections work fine on many machines, some local Python environments (notably macOS) fail due to missing or outdated root certificates. This causes SSL verification errors like CERTIFICATE_VERIFY_FAILED.

**What this PR does:**

Adds explicit SSL context creation with certifi’s root certificates when connecting over wss.

Supports both ws and wss protocols without breaking existing functionality.

Ensures consistent SSL verification behavior across different local dev environments.

This change improves reliability of secure websocket connections for all developers without requiring manual certificate fixes.