### PR TITLE
Fix for #18 - Add RUN pip install after installing requirements 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN apk add --update --no-cache --virtual .build-deps g++ gcc libxml2-dev libxsl
 WORKDIR app
 COPY . .
 RUN pip install -r requirements.txt
+RUN pip install .
 ENTRYPOINT ["python","./docker_entry.py"]


### PR DESCRIPTION
The Dockerfile installs dependencies from requirements.txt, but never installs the package itself. With the src/ layout, the module lives at src/charge_device_simulator/ and is not on Python's import path unless installed via pip install ..

Fixes #18