### PR TITLE
Fix mutable class-level defaults in Simulator to prevent shared state bleed

### DIFF
--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -18,15 +18,15 @@ class Simulator:
         return self.__logger
 
     is_ended = False
-    flow_charge_options: dict = {}
     frequent_flow_enabled = True
     is_interactive = False
-    frequent_flows: typing.Dict[Flows, FrequentFlowOptions] = {}
-    on_error = []
 
     def __init__(self, device: DeviceAbstract):
         self.device = device
         self.name = ''
+        self.flow_charge_options = {}
+        self.frequent_flows = {}
+        self.on_error = []
 
     async def loop_flow_frequent(self):
         time_loop = 0

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -17,15 +17,14 @@ class Simulator:
     def logger(self) -> logging.Logger:
         return self.__logger
 
-    is_ended = False
-    frequent_flow_enabled = True
-    is_interactive = False
-
     def __init__(self, device: DeviceAbstract):
         self.device = device
         self.name = ''
-        self.flow_charge_options = {}
-        self.frequent_flows = {}
+        self.is_ended = False
+        self.flow_charge_options: dict = {}
+        self.frequent_flow_enabled = True
+        self.is_interactive = False
+        self.frequent_flows: typing.Dict[Flows, FrequentFlowOptions] = {}
         self.on_error = []
 
     async def loop_flow_frequent(self):


### PR DESCRIPTION
Move flow_charge_options, frequent_flows, and on_error initialization from class-level attributes to __init__. As class-level mutable defaults (dict/list), these would be shared across all Simulator instances in the same process. While ConfigParser currently overwrites them before use, this removes a latent bug that would surface if Simulator were ever instantiated without going through ConfigParser.

Fixes #17 