### PR TITLE
Add 'preparing' flow to keep charger in OCPP PREPARING state

### DIFF
--- a/how-to-use/README.md
+++ b/how-to-use/README.md
@@ -21,16 +21,16 @@ Check the comments inside the config.yaml file to see available options
 | `heartbeat` | Sends periodic heartbeat messages to the server |
 | `authorize` | Sends periodic authorize requests |
 | `charge` | Runs a full charging session (authorize, start, meter values, stop) |
-| `preparing` | Keeps the charger in OCPP PREPARING state by periodically sending a StatusNotification. Simulates a charger with a cable always plugged in. Skips if a charge is already in progress. When active, charge sessions end with Preparing instead of Available. Useful for chargers that should accept remote-start sessions without ever going back to Available. |
+| `status_preparing` | Keeps the charger in OCPP PREPARING state by periodically sending a StatusNotification. Simulates a charger with a cable always plugged in. Skips if a charge is already in progress. When active, charge sessions end with Preparing instead of Available. Useful for chargers that should accept remote-start sessions without ever going back to Available. |
 
 ## Example: charger waiting for remote start
-A common setup is `heartbeat` + `preparing` — the charger stays in PREPARING and only charges when triggered by a RemoteStartTransaction from the server:
+A common setup is `heartbeat` + `status_preparing` — the charger stays in PREPARING and only charges when triggered by a RemoteStartTransaction from the server:
 ```yaml
 frequent_flows:
   - flow: heartbeat
     delay_seconds: 30
     count: -1
-  - flow: preparing
+  - flow: status_preparing
     delay_seconds: 60
     count: -1
 ```

--- a/how-to-use/README.md
+++ b/how-to-use/README.md
@@ -13,3 +13,24 @@ then edit `docker-compose.yml` file and change `--simulation=sim1` to
 # config.yaml
 Here you define devices with their specs and simulation to be run.  
 Check the comments inside the config.yaml file to see available options
+
+# Available flows
+
+| Flow | Description |
+|------|-------------|
+| `heartbeat` | Sends periodic heartbeat messages to the server |
+| `authorize` | Sends periodic authorize requests |
+| `charge` | Runs a full charging session (authorize, start, meter values, stop) |
+| `preparing` | Keeps the charger in OCPP PREPARING state by periodically sending a StatusNotification. Simulates a charger with a cable always plugged in. Skips if a charge is already in progress. When active, charge sessions end with Preparing instead of Available. Useful for chargers that should accept remote-start sessions without ever going back to Available. |
+
+## Example: charger waiting for remote start
+A common setup is `heartbeat` + `preparing` — the charger stays in PREPARING and only charges when triggered by a RemoteStartTransaction from the server:
+```yaml
+frequent_flows:
+  - flow: heartbeat
+    delay_seconds: 30
+    count: -1
+  - flow: preparing
+    delay_seconds: 60
+    count: -1
+```

--- a/how-to-use/config.yaml
+++ b/how-to-use/config.yaml
@@ -20,6 +20,9 @@ simulations:
       - flow: charge # A full session of charging (status, start/stop, meter values, ...)
         delay_seconds: 180 # delay between each run in seconds
         count: 5 # How many times this flow should be run, if -1 it would run forever
+      - flow: preparing # Keeps the charger in PREPARING state (simulates cable always plugged in). Skips if a charge is in progress. When used, the charge flow will end with Preparing instead of Available.
+        delay_seconds: 60 # delay between each run in seconds
+        count: -1 # How many times this flow should be run, if -1 it would run forever
 
 # All your devices identified by their name
 devices:

--- a/how-to-use/config.yaml
+++ b/how-to-use/config.yaml
@@ -20,7 +20,7 @@ simulations:
       - flow: charge # A full session of charging (status, start/stop, meter values, ...)
         delay_seconds: 180 # delay between each run in seconds
         count: 5 # How many times this flow should be run, if -1 it would run forever
-      - flow: preparing # Keeps the charger in PREPARING state (simulates cable always plugged in). Skips if a charge is in progress. When used, the charge flow will end with Preparing instead of Available.
+      - flow: status_preparing # Keeps the charger in PREPARING state (simulates cable always plugged in). Skips if a charge is in progress. When used, the charge flow will end with Preparing instead of Available.
         delay_seconds: 60 # delay between each run in seconds
         count: -1 # How many times this flow should be run, if -1 it would run forever
 

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -115,7 +115,7 @@ class DeviceAbstract(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def flow_preparing(self) -> bool:
+    async def flow_status_preparing(self) -> bool:
         pass
 
     @abc.abstractmethod

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -18,6 +18,7 @@ class DeviceAbstract(abc.ABC):
         self.deviceId: str = device_id
         self.name: str = ''
         self.charge_in_progress: bool = False
+        self.is_preparing: bool = False
         self.charge_id: typing.Any = -1
         # Set True by Simulator.lifecycle_start when running an interactive
         # session. Enables UX-only behaviors (e.g. refreshing per-cycle
@@ -111,6 +112,10 @@ class DeviceAbstract(abc.ABC):
 
     @abc.abstractmethod
     async def flow_authorize(self, options: dict) -> bool:
+        pass
+
+    @abc.abstractmethod
+    async def flow_preparing(self) -> bool:
         pass
 
     @abc.abstractmethod

--- a/src/charge_device_simulator/device/ensto/device_ensto.py
+++ b/src/charge_device_simulator/device/ensto/device_ensto.py
@@ -229,8 +229,8 @@ class DeviceEnsto(device_abstract.DeviceAbstract):
         self.logger.info(f"Flow {log_title} End")
         return True
 
-    async def flow_preparing(self) -> bool:
-        log_title = self.flow_preparing.__name__
+    async def flow_status_preparing(self) -> bool:
+        log_title = self.flow_status_preparing.__name__
         self.logger.info(f"Flow {log_title} Start")
         self.logger.info(f"Flow {log_title} End (no-op for Ensto)")
         return True

--- a/src/charge_device_simulator/device/ensto/device_ensto.py
+++ b/src/charge_device_simulator/device/ensto/device_ensto.py
@@ -229,6 +229,12 @@ class DeviceEnsto(device_abstract.DeviceAbstract):
         self.logger.info(f"Flow {log_title} End")
         return True
 
+    async def flow_preparing(self) -> bool:
+        log_title = self.flow_preparing.__name__
+        self.logger.info(f"Flow {log_title} Start")
+        self.logger.info(f"Flow {log_title} End (no-op for Ensto)")
+        return True
+
     async def flow_charge(self, auto_stop: bool, options: dict) -> bool:
         log_title = self.flow_charge.__name__
         self.logger.info(f"Flow {log_title} Start")

--- a/src/charge_device_simulator/device/flows.py
+++ b/src/charge_device_simulator/device/flows.py
@@ -5,4 +5,4 @@ class Flows(Enum):
     Heartbeat = 'heartbeat'
     Authorize = 'authorize'
     Charge = 'charge'
-    Preparing = 'preparing'
+    StatusPreparing = 'status_preparing'

--- a/src/charge_device_simulator/device/flows.py
+++ b/src/charge_device_simulator/device/flows.py
@@ -5,3 +5,4 @@ class Flows(Enum):
     Heartbeat = 'heartbeat'
     Authorize = 'authorize'
     Charge = 'charge'
+    Preparing = 'preparing'

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -160,6 +160,19 @@ class AbstractDeviceOcppJ(DeviceAbstract):
         self.logger.info(f"Flow {log_title} End")
         return True
 
+    async def flow_preparing(self) -> bool:
+        log_title = self.flow_preparing.__name__
+        self.logger.info(f"Flow {log_title} Start")
+        if self.charge_in_progress:
+            self.logger.info(f"Flow {log_title} Skipped, charge in progress")
+        else:
+            self.is_preparing = True
+            if not await self.action_status_update("Preparing", {}):
+                self.is_preparing = False
+                return False
+        self.logger.info(f"Flow {log_title} End")
+        return True
+
     async def flow_charge(self, auto_stop: bool, options: dict) -> bool:
         log_title = self.flow_charge.__name__
         self.logger.info(f"Flow {log_title} Start")
@@ -189,9 +202,14 @@ class AbstractDeviceOcppJ(DeviceAbstract):
         if not await self.action_charge_stop(options):
             self.charge_in_progress = False
             return False
-        if not await self.action_status_update("Available", options):
-            self.charge_in_progress = False
-            return False
+        if self.is_preparing:
+            if not await self.action_status_update("Preparing", options):
+                self.charge_in_progress = False
+                return False
+        else:
+            if not await self.action_status_update("Available", options):
+                self.charge_in_progress = False
+                return False
         self.logger.info(f"Flow {log_title} End")
         self.charge_in_progress = False
         return True
@@ -324,6 +342,8 @@ class AbstractDeviceOcppJ(DeviceAbstract):
                 }
                 if self.charge_in_progress:
                     next_async_task = await self.action_status_update("Charging", options)
+                elif self.is_preparing:
+                    next_async_task = await self.action_status_update("Preparing", options)
                 else:
                     next_async_task = await self.action_status_update("Available", options)
         if req_action == "RemoteStartTransaction".lower():

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -160,8 +160,8 @@ class AbstractDeviceOcppJ(DeviceAbstract):
         self.logger.info(f"Flow {log_title} End")
         return True
 
-    async def flow_preparing(self) -> bool:
-        log_title = self.flow_preparing.__name__
+    async def flow_status_preparing(self) -> bool:
+        log_title = self.flow_status_preparing.__name__
         self.logger.info(f"Flow {log_title} Start")
         if self.charge_in_progress:
             self.logger.info(f"Flow {log_title} Skipped, charge in progress")

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -247,8 +247,8 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         self.logger.info(f"Action {action} End")
         return True
 
-    async def flow_preparing(self) -> bool:
-        log_title = self.flow_preparing.__name__
+    async def flow_status_preparing(self) -> bool:
+        log_title = self.flow_status_preparing.__name__
         self.logger.info(f"Flow {log_title} Start")
         if self.charge_in_progress:
             self.logger.info(f"Flow {log_title} Skipped, charge in progress")

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -247,6 +247,19 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         self.logger.info(f"Action {action} End")
         return True
 
+    async def flow_preparing(self) -> bool:
+        log_title = self.flow_preparing.__name__
+        self.logger.info(f"Flow {log_title} Start")
+        if self.charge_in_progress:
+            self.logger.info(f"Flow {log_title} Skipped, charge in progress")
+        else:
+            self.is_preparing = True
+            if not await self.action_status_update("Occupied", {}):
+                self.is_preparing = False
+                return False
+        self.logger.info(f"Flow {log_title} End")
+        return True
+
     async def flow_charge(self, auto_stop: bool, options: dict) -> bool:
         log_title = self.flow_charge.__name__
         self.logger.info(f"Flow {log_title} Start")
@@ -270,9 +283,14 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         if not await self.action_charge_stop(options):
             self.charge_in_progress = False
             return False
-        if not await self.action_status_update("Available", options):
-            self.charge_in_progress = False
-            return False
+        if self.is_preparing:
+            if not await self.action_status_update("Occupied", options):
+                self.charge_in_progress = False
+                return False
+        else:
+            if not await self.action_status_update("Available", options):
+                self.charge_in_progress = False
+                return False
         self.logger.info(f"Flow {log_title} End")
         self.charge_in_progress = False
         return True

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -299,6 +299,19 @@ class DeviceOcppS(DeviceAbstract):
         self.logger.info(f"Flow {log_title} End")
         return True
 
+    async def flow_preparing(self) -> bool:
+        log_title = self.flow_preparing.__name__
+        self.logger.info(f"Flow {log_title} Start")
+        if self.charge_in_progress:
+            self.logger.info(f"Flow {log_title} Skipped, charge in progress")
+        else:
+            self.is_preparing = True
+            if not await self.action_status_update("Preparing", {}):
+                self.is_preparing = False
+                return False
+        self.logger.info(f"Flow {log_title} End")
+        return True
+
     async def flow_charge(self, auto_stop: bool, options: dict) -> bool:
         log_title = self.flow_charge.__name__
         self.logger.info(f"Flow {log_title} Start")
@@ -328,9 +341,14 @@ class DeviceOcppS(DeviceAbstract):
         if not await self.action_charge_stop(options):
             self.charge_in_progress = False
             return False
-        if not await self.action_status_update("Available", options):
-            self.charge_in_progress = False
-            return False
+        if self.is_preparing:
+            if not await self.action_status_update("Preparing", options):
+                self.charge_in_progress = False
+                return False
+        else:
+            if not await self.action_status_update("Available", options):
+                self.charge_in_progress = False
+                return False
         self.logger.info(f"Flow {log_title} End")
         self.charge_in_progress = False
         return True

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -299,8 +299,8 @@ class DeviceOcppS(DeviceAbstract):
         self.logger.info(f"Flow {log_title} End")
         return True
 
-    async def flow_preparing(self) -> bool:
-        log_title = self.flow_preparing.__name__
+    async def flow_status_preparing(self) -> bool:
+        log_title = self.flow_status_preparing.__name__
         self.logger.info(f"Flow {log_title} Start")
         if self.charge_in_progress:
             self.logger.info(f"Flow {log_title} Skipped, charge in progress")

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -61,8 +61,8 @@ class Simulator:
                             True,
                             self.flow_charge_options
                         )
-                    elif f_flow == Flows.Preparing:
-                        task_def = self.device.flow_preparing()
+                    elif f_flow == Flows.StatusPreparing:
+                        task_def = self.device.flow_status_preparing()
                     if task_def is not None:
                         self.logger.info(
                             f"Frequent Flow, Started, Flow: {f_flow}, Time: {time_loop}")

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -61,6 +61,8 @@ class Simulator:
                             True,
                             self.flow_charge_options
                         )
+                    elif f_flow == Flows.Preparing:
+                        task_def = self.device.flow_preparing()
                     if task_def is not None:
                         self.logger.info(
                             f"Frequent Flow, Started, Flow: {f_flow}, Time: {time_loop}")

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -120,6 +120,98 @@ class TestChargeMeterValueCurrent:
         assert second_result > first_result
 
 
+class TestFlowAutoPreparing:
+    """Tests for the flow_preparing method."""
+
+    @pytest.mark.asyncio
+    async def test_skips_status_update_when_charge_in_progress(self, ocpp_j_device):
+        """preparing should be a no-op when a charge is in progress."""
+        ocpp_j_device.charge_in_progress = True
+        ocpp_j_device.is_preparing = False
+
+        result = await ocpp_j_device.flow_preparing()
+
+        assert result is True
+        assert ocpp_j_device.is_preparing is False
+
+    @pytest.mark.asyncio
+    async def test_sends_preparing_when_idle(self, ocpp_j_device):
+        """preparing should send Preparing status when charger is idle."""
+        ocpp_j_device.charge_in_progress = False
+        ocpp_j_device.is_preparing = False
+
+        result = await ocpp_j_device.flow_preparing()
+
+        assert result is True
+        assert ocpp_j_device.is_preparing is True
+
+    @pytest.mark.asyncio
+    async def test_status_update_failure_resets_is_preparing(self, ocpp_j_device):
+        """If status_update fails, is_preparing should be reset to False."""
+        ocpp_j_device.charge_in_progress = False
+
+        async def fail_status(status, options):
+            return False
+        ocpp_j_device.action_status_update = fail_status
+
+        result = await ocpp_j_device.flow_preparing()
+
+        assert result is False
+        assert ocpp_j_device.is_preparing is False
+
+    @pytest.mark.asyncio
+    async def test_flow_charge_ends_with_preparing_when_is_preparing(self, ocpp_j_device):
+        """flow_charge should end with Preparing (not Available) when is_preparing is True."""
+        ocpp_j_device.is_preparing = True
+
+        status_calls = []
+        async def track_status(status, options):
+            status_calls.append(status)
+            return True
+        ocpp_j_device.action_status_update = track_status
+
+        with patch('asyncio.sleep', new_callable=AsyncMock):
+            result = await ocpp_j_device.flow_charge(True, {})
+
+        assert result is True
+        assert status_calls[-1] == "Preparing"
+        assert ocpp_j_device.is_preparing is True
+
+    @pytest.mark.asyncio
+    async def test_is_preparing_survives_charge_failure(self, ocpp_j_device):
+        """is_preparing should remain True if flow_charge fails mid-way."""
+        ocpp_j_device.is_preparing = True
+
+        async def fail_authorize(options):
+            return False
+        ocpp_j_device.action_authorize = fail_authorize
+
+        result = await ocpp_j_device.flow_charge(True, {})
+
+        assert result is False
+        assert ocpp_j_device.is_preparing is True
+
+    @pytest.mark.asyncio
+    async def test_trigger_message_reports_preparing(self, ocpp_j_device):
+        """TriggerMessage StatusNotification should report Preparing when is_preparing is True."""
+        ocpp_j_device.charge_in_progress = False
+        ocpp_j_device.is_preparing = True
+        ocpp_j_device._ws = MagicMock()
+        ocpp_j_device._ws.send = AsyncMock()
+
+        status_calls = []
+        async def track_status(status, options):
+            status_calls.append(status)
+        ocpp_j_device.action_status_update = track_status
+
+        await ocpp_j_device.by_middleware_req(
+            "req-1", "triggermessage",
+            {"requestedMessage": "StatusNotification"}
+        )
+
+        assert status_calls == ["Preparing"]
+
+
 class TestOptionsPersistence:
     """Tests to verify that options dict modifications persist to caller."""
 

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -120,8 +120,8 @@ class TestChargeMeterValueCurrent:
         assert second_result > first_result
 
 
-class TestFlowAutoPreparing:
-    """Tests for the flow_preparing method."""
+class TestFlowStatusPreparing:
+    """Tests for the flow_status_preparing method."""
 
     @pytest.mark.asyncio
     async def test_skips_status_update_when_charge_in_progress(self, ocpp_j_device):
@@ -129,7 +129,7 @@ class TestFlowAutoPreparing:
         ocpp_j_device.charge_in_progress = True
         ocpp_j_device.is_preparing = False
 
-        result = await ocpp_j_device.flow_preparing()
+        result = await ocpp_j_device.flow_status_preparing()
 
         assert result is True
         assert ocpp_j_device.is_preparing is False
@@ -140,7 +140,7 @@ class TestFlowAutoPreparing:
         ocpp_j_device.charge_in_progress = False
         ocpp_j_device.is_preparing = False
 
-        result = await ocpp_j_device.flow_preparing()
+        result = await ocpp_j_device.flow_status_preparing()
 
         assert result is True
         assert ocpp_j_device.is_preparing is True
@@ -154,7 +154,7 @@ class TestFlowAutoPreparing:
             return False
         ocpp_j_device.action_status_update = fail_status
 
-        result = await ocpp_j_device.flow_preparing()
+        result = await ocpp_j_device.flow_status_preparing()
 
         assert result is False
         assert ocpp_j_device.is_preparing is False

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -15,6 +15,7 @@ def mock_device():
     device.flow_authorize = AsyncMock(return_value=True)
     device.flow_charge = AsyncMock(return_value=True)
     device.flow_heartbeat = AsyncMock(return_value=True)
+    device.flow_preparing = AsyncMock(return_value=True)
     device.re_initialize = AsyncMock(return_value=True)
     device.on_error = []
     return device
@@ -84,6 +85,15 @@ class TestSimulatorFlowOptionsPassedAsDict:
             await simulator.loop_interactive()
 
         mock_device.flow_authorize.assert_called_once_with(simulator.flow_charge_options)
+
+    @pytest.mark.asyncio
+    async def test_frequent_flow_preparing(self, simulator, mock_device):
+        """Test that frequent flow preparing dispatches correctly."""
+        simulator.frequent_flows = {
+            Flows.Preparing: FrequentFlowOptions(delay_seconds=0, count=1)
+        }
+        await simulator.loop_flow_frequent()
+        mock_device.flow_preparing.assert_called_once()
 
 
 class TestSimulatorOptionsPersistence:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -15,7 +15,7 @@ def mock_device():
     device.flow_authorize = AsyncMock(return_value=True)
     device.flow_charge = AsyncMock(return_value=True)
     device.flow_heartbeat = AsyncMock(return_value=True)
-    device.flow_preparing = AsyncMock(return_value=True)
+    device.flow_status_preparing = AsyncMock(return_value=True)
     device.re_initialize = AsyncMock(return_value=True)
     device.on_error = []
     return device
@@ -87,13 +87,13 @@ class TestSimulatorFlowOptionsPassedAsDict:
         mock_device.flow_authorize.assert_called_once_with(simulator.flow_charge_options)
 
     @pytest.mark.asyncio
-    async def test_frequent_flow_preparing(self, simulator, mock_device):
+    async def test_frequent_flow_status_preparing(self, simulator, mock_device):
         """Test that frequent flow preparing dispatches correctly."""
         simulator.frequent_flows = {
-            Flows.Preparing: FrequentFlowOptions(delay_seconds=0, count=1)
+            Flows.StatusPreparing: FrequentFlowOptions(delay_seconds=0, count=1)
         }
         await simulator.loop_flow_frequent()
-        mock_device.flow_preparing.assert_called_once()
+        mock_device.flow_status_preparing.assert_called_once()
 
 
 class TestSimulatorOptionsPersistence:


### PR DESCRIPTION
## Summary

New `preparing` flow that keeps the simulated charger in OCPP `PREPARING` state — like a charger with a cable always plugged in.

Configure it alongside heartbeat:
```yaml
frequent_flows:
- flow: heartbeat
  delay_seconds: 30
  count: -1
- flow: preparing
  delay_seconds: 60
  count: -1
  ```

The charger periodically sends StatusNotification("Preparing") and never goes back to Available. When a `RemoteStartTransaction` comes in, the charge proceeds normally. After the charge ends, the final status is `Preparing` (not `Available`).

## How it works

- flow_preparing checks charge_in_progress — if true, it's a no-op (logs "Skipped, charge in progress")
- is_preparing flag tracks state so TriggerMessage → StatusNotification reports correctly
- The flag is never cleared during flow_charge, so it survives failures and remote stops without gaps
- OCPP 2.0.1 uses "Occupied" instead of "Preparing" per spec
- Ensto implementation is a no-op (no OCPP-style preparing concept)
- Without the flow configured, existing behavior is unchanged

## Test plan

- 43 unit tests pass (7 new)
- Tested with live Virta server: preparing → remote start → charge → remote stop → preparing
- Verified without the flow: charge ends with Available as before