### PR TITLE
Add OCPP reservation support (1.6, 2.0.1, OCPP-S) and enum-aware interactive picker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml
 zeep[async]
 certifi
 pytest
+questionary>=2.0

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -5,6 +5,8 @@ import logging
 import os
 import sys
 
+import aioconsole
+
 from .error_reasons import ErrorReasons
 
 
@@ -17,6 +19,12 @@ class DeviceAbstract(abc.ABC):
         self.name = ''
         self.charge_in_progress = False
         self.charge_id = -1
+        self.reservation_id = None
+        self.reservation_connector_id = None
+        self.reservation_id_tag = None
+        self.reservation_parent_id_tag = None
+        self.reservation_expiry_date = None
+        self._last_authorize_info = None
         envKey = 'RESPONSE_TIMEOUT_SECONDS'
         self.response_timeout_seconds = int(os.environ[envKey]) if envKey in os.environ else 15
 
@@ -148,6 +156,152 @@ class DeviceAbstract(abc.ABC):
 
     def charge_can_stop(self, req_id):
         return self.charge_in_progress and self.charge_id == req_id
+
+    def reservation_is_active(self) -> bool:
+        return self.reservation_id is not None
+
+    def reserve_can_accept(self, connector_id) -> bool:
+        if self.charge_in_progress:
+            return False
+        if self.reservation_is_active() and self.reservation_connector_id == connector_id:
+            return False
+        return True
+
+    def reserve_can_cancel(self, reservation_id) -> bool:
+        return self.reservation_is_active() and self.reservation_id == reservation_id
+
+    def reservation_set(self, reservation_id, connector_id, id_tag, parent_id_tag, expiry_date):
+        self.reservation_id = reservation_id
+        self.reservation_connector_id = connector_id
+        self.reservation_id_tag = id_tag
+        self.reservation_parent_id_tag = parent_id_tag
+        self.reservation_expiry_date = expiry_date
+
+    def reservation_clear(self):
+        self.reservation_id = None
+        self.reservation_connector_id = None
+        self.reservation_id_tag = None
+        self.reservation_parent_id_tag = None
+        self.reservation_expiry_date = None
+
+    def _pre_charge_reservation_gate(self, options: dict) -> bool:
+        """If the connector has an active reservation, validate the most recent
+        authorize info against it (direct idTag or parent/group match). On match,
+        injects reservationId into options so the start payload carries it."""
+        connector_id = options.get("connectorId")
+        if not self.reservation_is_active() or self.reservation_connector_id != connector_id:
+            return True
+        requested_id_tag = options.get("idTag")
+        if requested_id_tag is not None and requested_id_tag == self.reservation_id_tag:
+            options["reservationId"] = self.reservation_id
+            return True
+        last_parent = (self._last_authorize_info or {}).get("parent_id_tag")
+        if (last_parent is not None
+                and self.reservation_parent_id_tag is not None
+                and last_parent == self.reservation_parent_id_tag):
+            options["reservationId"] = self.reservation_id
+            return True
+        self.logger.info(
+            f"Reservation gate rejected charge: requested idTag/parent did not match reservation "
+            f"{self.reservation_id} on connector {connector_id}")
+        return False
+
+    def _consume_reservation_if_used(self, options: dict):
+        if "reservationId" in options and self.reservation_is_active() \
+                and options["reservationId"] == self.reservation_id:
+            self.logger.info(f"Reservation {self.reservation_id} consumed by charge start")
+            self.reservation_clear()
+
+    def _reserve_now_options_from_payload(self, req_payload: dict) -> dict:
+        """Convert an inbound ReserveNow.req payload into the dict shape
+        flow_reserve expects. Default covers OCPP 1.6 / OCPP-S 1.5 SOAP.
+        Overridden for OCPP 2.0.1."""
+        return {
+            "reservationId": req_payload.get("reservationId"),
+            "connectorId": req_payload.get("connectorId"),
+            "idTag": req_payload.get("idTag"),
+            "parentIdTag": req_payload.get("parentIdTag"),
+            "expiryDate": req_payload.get("expiryDate"),
+        }
+
+    async def flow_reserve(self, options: dict) -> bool:
+        """Apply a ReserveNow request: validate, store state, send Reserved
+        StatusNotification. Returns True if reservation was accepted."""
+        log_title = self.flow_reserve.__name__
+        self.logger.info(f"Flow {log_title} Start: connectorId={options.get('connectorId')}, "
+                         f"reservationId={options.get('reservationId')}")
+        connector_id = options.get("connectorId")
+        if not self.reserve_can_accept(connector_id):
+            self.logger.info(f"Flow {log_title} Rejected (connector busy or already reserved)")
+            return False
+        self.reservation_set(
+            reservation_id=options.get("reservationId"),
+            connector_id=connector_id,
+            id_tag=options.get("idTag"),
+            parent_id_tag=options.get("parentIdTag"),
+            expiry_date=options.get("expiryDate"),
+        )
+        if not await self.action_status_update("Reserved", options):
+            return False
+        self.logger.info(f"Flow {log_title} End")
+        return True
+
+    interactive_reservation_menu = """3: Show reservation state
+4: Make reservation (simulate ReserveNow)
+5: Cancel reservation (simulate CancelReservation)
+"""
+
+    async def interactive_reservation_handle(self, input_choice: str) -> bool:
+        """Handle reservation-related entries from a device's interactive menu.
+        Returns True if the input was handled."""
+        if input_choice == "3":
+            self.logger.info(
+                f"Reservation state: id={self.reservation_id}, "
+                f"connectorId={self.reservation_connector_id}, "
+                f"idTag={self.reservation_id_tag}, "
+                f"parentIdTag={self.reservation_parent_id_tag}, "
+                f"expiryDate={self.reservation_expiry_date}")
+            return True
+        if input_choice == "4":
+            reservation_id = await aioconsole.ainput("reservationId (integer):\n")
+            connector_id = await aioconsole.ainput("connectorId:\n")
+            id_tag = await aioconsole.ainput("idTag:\n")
+            parent_id_tag = await aioconsole.ainput("parentIdTag (blank to skip):\n")
+            expiry_date = await aioconsole.ainput("expiryDate ISO (blank for now+1h):\n")
+            options = {
+                "reservationId": int(reservation_id) if reservation_id else None,
+                "connectorId": int(connector_id) if connector_id else None,
+                "evseId": int(connector_id) if connector_id else None,
+                "idTag": id_tag or None,
+                "parentIdTag": parent_id_tag or None,
+                "expiryDate": expiry_date or (
+                    self.utcnow() + datetime.timedelta(hours=1)).isoformat(),
+            }
+            await self.flow_reserve(options)
+            return True
+        if input_choice == "5":
+            reservation_id_input = await aioconsole.ainput(
+                "reservationId (blank uses stored):\n")
+            reservation_id = (int(reservation_id_input)
+                              if reservation_id_input
+                              else self.reservation_id)
+            await self.flow_reservation_cancel(reservation_id)
+            return True
+        return False
+
+    async def flow_reservation_cancel(self, reservation_id, options: dict = None) -> bool:
+        log_title = self.flow_reservation_cancel.__name__
+        self.logger.info(f"Flow {log_title} Start: reservationId={reservation_id}")
+        if not self.reserve_can_cancel(reservation_id):
+            self.logger.info(f"Flow {log_title} Rejected (no matching reservation)")
+            return False
+        notify_options = dict(options) if options else {}
+        notify_options.setdefault("connectorId", self.reservation_connector_id)
+        self.reservation_clear()
+        if not await self.action_status_update("Available", notify_options):
+            return False
+        self.logger.info(f"Flow {log_title} End")
+        return True
 
     @abc.abstractmethod
     def charge_meter_value_current(self, options: dict):

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -19,6 +19,11 @@ class DeviceAbstract(abc.ABC):
         self.name: str = ''
         self.charge_in_progress: bool = False
         self.charge_id: typing.Any = -1
+        # Set True by Simulator.lifecycle_start when running an interactive
+        # session. Enables UX-only behaviors (e.g. refreshing per-cycle
+        # ephemeral options on each flow_charge); never affects non-interactive
+        # / frequent-flow runs.
+        self.interactive_mode: bool = False
         self.reservation_id: typing.Optional[int] = None
         self.reservation_connector_id: typing.Optional[int] = None
         self.reservation_id_tag: typing.Optional[str] = None
@@ -218,6 +223,18 @@ class DeviceAbstract(abc.ABC):
             f"Reservation gate rejected charge: requested idTag/parent did not match reservation "
             f"{self.reservation_id} on connector {connector_id}")
         return False
+
+    def _reset_charge_cycle_options(self, options: typing.Dict[str, typing.Any]) -> None:
+        """In interactive mode only, drop per-cycle ephemeral keys so a re-run
+        of flow_charge picks up fresh start/stop timestamps and a recomputed
+        meterStop. Without this, a second Flow charge in the same interactive
+        session would replay the first cycle's `chargeStartTime` because the
+        dict is shared. Frequent-flow / non-interactive runs are intentionally
+        unaffected — they construct their own options each loop iteration."""
+        if not self.interactive_mode:
+            return
+        for key in ("chargeStartTime", "chargeStopTime", "meterStop"):
+            options.pop(key, None)
 
     def _consume_reservation_if_used(self, options: typing.Dict[str, typing.Any]) -> None:
         if "reservationId" in options and self.reservation_is_active() \

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import os
 import sys
+import typing
 
 import aioconsole
 
@@ -13,20 +14,20 @@ from .error_reasons import ErrorReasons
 class DeviceAbstract(abc.ABC):
     on_error = []
 
-    def __init__(self, device_id):
-        self.register_on_initialize = True
-        self.deviceId = device_id
-        self.name = ''
-        self.charge_in_progress = False
-        self.charge_id = -1
-        self.reservation_id = None
-        self.reservation_connector_id = None
-        self.reservation_id_tag = None
-        self.reservation_parent_id_tag = None
-        self.reservation_expiry_date = None
-        self._last_authorize_info = None
+    def __init__(self, device_id: str):
+        self.register_on_initialize: bool = True
+        self.deviceId: str = device_id
+        self.name: str = ''
+        self.charge_in_progress: bool = False
+        self.charge_id: typing.Any = -1
+        self.reservation_id: typing.Optional[int] = None
+        self.reservation_connector_id: typing.Optional[int] = None
+        self.reservation_id_tag: typing.Optional[str] = None
+        self.reservation_parent_id_tag: typing.Optional[str] = None
+        self.reservation_expiry_date: typing.Optional[str] = None
+        self._last_authorize_info: typing.Optional[typing.Dict[str, typing.Optional[str]]] = None
         envKey = 'RESPONSE_TIMEOUT_SECONDS'
-        self.response_timeout_seconds = int(os.environ[envKey]) if envKey in os.environ else 15
+        self.response_timeout_seconds: int = int(os.environ[envKey]) if envKey in os.environ else 15
 
     @property
     @abc.abstractmethod
@@ -160,31 +161,38 @@ class DeviceAbstract(abc.ABC):
     def reservation_is_active(self) -> bool:
         return self.reservation_id is not None
 
-    def reserve_can_accept(self, connector_id) -> bool:
+    def reserve_can_accept(self, connector_id: typing.Optional[int]) -> bool:
         if self.charge_in_progress:
             return False
         if self.reservation_is_active() and self.reservation_connector_id == connector_id:
             return False
         return True
 
-    def reserve_can_cancel(self, reservation_id) -> bool:
+    def reserve_can_cancel(self, reservation_id: typing.Optional[int]) -> bool:
         return self.reservation_is_active() and self.reservation_id == reservation_id
 
-    def reservation_set(self, reservation_id, connector_id, id_tag, parent_id_tag, expiry_date):
+    def reservation_set(
+        self,
+        reservation_id: typing.Optional[int],
+        connector_id: typing.Optional[int],
+        id_tag: typing.Optional[str],
+        parent_id_tag: typing.Optional[str],
+        expiry_date: typing.Optional[str],
+    ) -> None:
         self.reservation_id = reservation_id
         self.reservation_connector_id = connector_id
         self.reservation_id_tag = id_tag
         self.reservation_parent_id_tag = parent_id_tag
         self.reservation_expiry_date = expiry_date
 
-    def reservation_clear(self):
+    def reservation_clear(self) -> None:
         self.reservation_id = None
         self.reservation_connector_id = None
         self.reservation_id_tag = None
         self.reservation_parent_id_tag = None
         self.reservation_expiry_date = None
 
-    def _pre_charge_reservation_gate(self, options: dict) -> bool:
+    def _pre_charge_reservation_gate(self, options: typing.Dict[str, typing.Any]) -> bool:
         """If the connector has an active reservation, validate the most recent
         authorize info against it (direct idTag or parent/group match). On match,
         injects reservationId into options so the start payload carries it."""
@@ -206,13 +214,15 @@ class DeviceAbstract(abc.ABC):
             f"{self.reservation_id} on connector {connector_id}")
         return False
 
-    def _consume_reservation_if_used(self, options: dict):
+    def _consume_reservation_if_used(self, options: typing.Dict[str, typing.Any]) -> None:
         if "reservationId" in options and self.reservation_is_active() \
                 and options["reservationId"] == self.reservation_id:
             self.logger.info(f"Reservation {self.reservation_id} consumed by charge start")
             self.reservation_clear()
 
-    def _reserve_now_options_from_payload(self, req_payload: dict) -> dict:
+    def _reserve_now_options_from_payload(
+        self, req_payload: typing.Dict[str, typing.Any],
+    ) -> typing.Dict[str, typing.Any]:
         """Convert an inbound ReserveNow.req payload into the dict shape
         flow_reserve expects. Default covers OCPP 1.6 / OCPP-S 1.5 SOAP.
         Overridden for OCPP 2.0.1."""
@@ -224,13 +234,13 @@ class DeviceAbstract(abc.ABC):
             "expiryDate": req_payload.get("expiryDate"),
         }
 
-    async def flow_reserve(self, options: dict) -> bool:
+    async def flow_reserve(self, options: typing.Dict[str, typing.Any]) -> bool:
         """Apply a ReserveNow request: validate, store state, send Reserved
         StatusNotification. Returns True if reservation was accepted."""
         log_title = self.flow_reserve.__name__
         self.logger.info(f"Flow {log_title} Start: connectorId={options.get('connectorId')}, "
                          f"reservationId={options.get('reservationId')}")
-        connector_id = options.get("connectorId")
+        connector_id: typing.Optional[int] = options.get("connectorId")
         if not self.reserve_can_accept(connector_id):
             self.logger.info(f"Flow {log_title} Rejected (connector busy or already reserved)")
             return False
@@ -246,7 +256,7 @@ class DeviceAbstract(abc.ABC):
         self.logger.info(f"Flow {log_title} End")
         return True
 
-    interactive_reservation_menu = """3: Show reservation state
+    interactive_reservation_menu: str = """3: Show reservation state
 4: Make reservation (simulate ReserveNow)
 5: Cancel reservation (simulate CancelReservation)
 """
@@ -263,39 +273,42 @@ class DeviceAbstract(abc.ABC):
                 f"expiryDate={self.reservation_expiry_date}")
             return True
         if input_choice == "4":
-            reservation_id = await aioconsole.ainput("reservationId (integer):\n")
-            connector_id = await aioconsole.ainput("connectorId:\n")
-            id_tag = await aioconsole.ainput("idTag:\n")
-            parent_id_tag = await aioconsole.ainput("parentIdTag (blank to skip):\n")
-            expiry_date = await aioconsole.ainput("expiryDate ISO (blank for now+1h):\n")
-            options = {
-                "reservationId": int(reservation_id) if reservation_id else None,
-                "connectorId": int(connector_id) if connector_id else None,
-                "evseId": int(connector_id) if connector_id else None,
-                "idTag": id_tag or None,
-                "parentIdTag": parent_id_tag or None,
-                "expiryDate": expiry_date or (
+            reservation_id_input: str = await aioconsole.ainput("reservationId (integer):\n")
+            connector_id_input: str = await aioconsole.ainput("connectorId:\n")
+            id_tag_input: str = await aioconsole.ainput("idTag:\n")
+            parent_id_tag_input: str = await aioconsole.ainput("parentIdTag (blank to skip):\n")
+            expiry_date_input: str = await aioconsole.ainput("expiryDate ISO (blank for now+1h):\n")
+            options: typing.Dict[str, typing.Any] = {
+                "reservationId": int(reservation_id_input) if reservation_id_input else None,
+                "connectorId": int(connector_id_input) if connector_id_input else None,
+                "evseId": int(connector_id_input) if connector_id_input else None,
+                "idTag": id_tag_input or None,
+                "parentIdTag": parent_id_tag_input or None,
+                "expiryDate": expiry_date_input or (
                     self.utcnow() + datetime.timedelta(hours=1)).isoformat(),
             }
             await self.flow_reserve(options)
             return True
         if input_choice == "5":
-            reservation_id_input = await aioconsole.ainput(
+            cancel_input: str = await aioconsole.ainput(
                 "reservationId (blank uses stored):\n")
-            reservation_id = (int(reservation_id_input)
-                              if reservation_id_input
-                              else self.reservation_id)
-            await self.flow_reservation_cancel(reservation_id)
+            cancel_reservation_id: typing.Optional[int] = (
+                int(cancel_input) if cancel_input else self.reservation_id)
+            await self.flow_reservation_cancel(cancel_reservation_id)
             return True
         return False
 
-    async def flow_reservation_cancel(self, reservation_id, options: dict = None) -> bool:
+    async def flow_reservation_cancel(
+        self,
+        reservation_id: typing.Optional[int],
+        options: typing.Optional[typing.Dict[str, typing.Any]] = None,
+    ) -> bool:
         log_title = self.flow_reservation_cancel.__name__
         self.logger.info(f"Flow {log_title} Start: reservationId={reservation_id}")
         if not self.reserve_can_cancel(reservation_id):
             self.logger.info(f"Flow {log_title} Rejected (no matching reservation)")
             return False
-        notify_options = dict(options) if options else {}
+        notify_options: typing.Dict[str, typing.Any] = dict(options) if options else {}
         notify_options.setdefault("connectorId", self.reservation_connector_id)
         self.reservation_clear()
         if not await self.action_status_update("Available", notify_options):

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -48,7 +48,13 @@ class DeviceAbstract(abc.ABC):
     error_exit = True
 
     async def handle_error(self, desc, reason: ErrorReasons) -> bool:
-        self.logger.exception(desc)
+        # Only log a traceback when there's actually a live exception. Plain
+        # `logger.exception` would otherwise render "NoneType: None" for
+        # protocol-level rejections that don't originate in an except block.
+        if sys.exc_info()[0] is not None:
+            self.logger.exception(desc)
+        else:
+            self.logger.error(desc)
         for event in self.on_error:
             await event(desc, reason)
         if self.error_exit:

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -206,7 +206,11 @@ class DeviceAbstract(abc.ABC):
         """If the connector has an active reservation, validate the most recent
         authorize info against it (direct idTag or parent/group match). On match,
         injects reservationId into options so the start payload carries it."""
-        connector_id = options.get("connectorId")
+        # Mirror action_charge_start's default — a missing connectorId would
+        # otherwise compare None against the stored connector and silently
+        # skip the gate (letting a non-matching tag through on a reserved
+        # connector).
+        connector_id = options.get("connectorId", 1)
         if not self.reservation_is_active() or self.reservation_connector_id != connector_id:
             return True
         requested_id_tag = options.get("idTag")

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -6,8 +6,7 @@ import os
 import sys
 import typing
 
-import aioconsole
-
+from . import utility
 from .error_reasons import ErrorReasons
 
 
@@ -256,47 +255,41 @@ class DeviceAbstract(abc.ABC):
         self.logger.info(f"Flow {log_title} End")
         return True
 
-    interactive_reservation_menu: str = """3: Show reservation state
-4: Make reservation (simulate ReserveNow)
-5: Cancel reservation (simulate CancelReservation)
-"""
+    async def interactive_reservation_show(self) -> None:
+        """Print the device's current reservation state."""
+        self.logger.info(
+            f"Reservation state: id={self.reservation_id}, "
+            f"connectorId={self.reservation_connector_id}, "
+            f"idTag={self.reservation_id_tag}, "
+            f"parentIdTag={self.reservation_parent_id_tag}, "
+            f"expiryDate={self.reservation_expiry_date}")
 
-    async def interactive_reservation_handle(self, input_choice: str) -> bool:
-        """Handle reservation-related entries from a device's interactive menu.
-        Returns True if the input was handled."""
-        if input_choice == "3":
-            self.logger.info(
-                f"Reservation state: id={self.reservation_id}, "
-                f"connectorId={self.reservation_connector_id}, "
-                f"idTag={self.reservation_id_tag}, "
-                f"parentIdTag={self.reservation_parent_id_tag}, "
-                f"expiryDate={self.reservation_expiry_date}")
-            return True
-        if input_choice == "4":
-            reservation_id_input: str = await aioconsole.ainput("reservationId (integer):\n")
-            connector_id_input: str = await aioconsole.ainput("connectorId:\n")
-            id_tag_input: str = await aioconsole.ainput("idTag:\n")
-            parent_id_tag_input: str = await aioconsole.ainput("parentIdTag (blank to skip):\n")
-            expiry_date_input: str = await aioconsole.ainput("expiryDate ISO (blank for now+1h):\n")
-            options: typing.Dict[str, typing.Any] = {
-                "reservationId": int(reservation_id_input) if reservation_id_input else None,
-                "connectorId": int(connector_id_input) if connector_id_input else None,
-                "evseId": int(connector_id_input) if connector_id_input else None,
-                "idTag": id_tag_input or None,
-                "parentIdTag": parent_id_tag_input or None,
-                "expiryDate": expiry_date_input or (
-                    self.utcnow() + datetime.timedelta(hours=1)).isoformat(),
-            }
-            await self.flow_reserve(options)
-            return True
-        if input_choice == "5":
-            cancel_input: str = await aioconsole.ainput(
-                "reservationId (blank uses stored):\n")
-            cancel_reservation_id: typing.Optional[int] = (
-                int(cancel_input) if cancel_input else self.reservation_id)
-            await self.flow_reservation_cancel(cancel_reservation_id)
-            return True
-        return False
+    async def interactive_reservation_make(self) -> None:
+        """Prompt for ReserveNow fields and run flow_reserve."""
+        reservation_id_input: str = await utility.prompt_text("reservationId (integer):")
+        connector_id_input: str = await utility.prompt_text("connectorId:")
+        id_tag_input: str = await utility.prompt_text("idTag:")
+        parent_id_tag_input: str = await utility.prompt_text("parentIdTag (blank to skip):")
+        expiry_date_input: str = await utility.prompt_text(
+            "expiryDate ISO (blank for now+1h):")
+        options: typing.Dict[str, typing.Any] = {
+            "reservationId": int(reservation_id_input) if reservation_id_input else None,
+            "connectorId": int(connector_id_input) if connector_id_input else None,
+            "evseId": int(connector_id_input) if connector_id_input else None,
+            "idTag": id_tag_input or None,
+            "parentIdTag": parent_id_tag_input or None,
+            "expiryDate": expiry_date_input or (
+                self.utcnow() + datetime.timedelta(hours=1)).isoformat(),
+        }
+        await self.flow_reserve(options)
+
+    async def interactive_reservation_cancel(self) -> None:
+        """Prompt for a reservationId (blank uses stored) and run flow_reservation_cancel."""
+        cancel_input: str = await utility.prompt_text(
+            "reservationId (blank uses stored):")
+        cancel_reservation_id: typing.Optional[int] = (
+            int(cancel_input) if cancel_input else self.reservation_id)
+        await self.flow_reservation_cancel(cancel_reservation_id)
 
     async def flow_reservation_cancel(
         self,

--- a/src/charge_device_simulator/device/ensto/device_ensto.py
+++ b/src/charge_device_simulator/device/ensto/device_ensto.py
@@ -6,8 +6,6 @@ import math
 import typing
 from urllib import parse
 
-import aioconsole
-
 from .. import abstract as device_abstract
 from .. import utility
 from .pending_req import PendingReq
@@ -415,24 +413,18 @@ class DeviceEnsto(device_abstract.DeviceAbstract):
         pass
 
     async def loop_interactive_custom(self):
-        is_back = False
-        while not is_back:
-            input1 = await aioconsole.ainput("""
-What should I do? (enter the number + enter)
-0: Back
-1: HeartBeat
-2: StatusUpdate
-99: Full Custom
-""")
-            if input1 == "0":
-                is_back = True
-            elif input1 == "1":
-                await self.action_heart_beat()
-            elif input1 == "2":
-                input1 = await aioconsole.ainput("Which status?\n")
-                await self.action_status_update(input1, {})
-            elif input1 == "99":
-                input1 = await aioconsole.ainput("Enter full raw request:\n")
-                req_json = self.__raw_to_json(input1)
-                await self.by_device_req_send(req_json['id'], req_json)
-        pass
+        await utility.run_menu("What should I do?", [
+            utility.MenuEntry("Back", is_back=True, shortcut="0"),
+            utility.MenuEntry("HeartBeat", self.action_heart_beat, shortcut="1"),
+            utility.MenuEntry("StatusUpdate", self._interactive_status_update, shortcut="2"),
+            utility.MenuEntry("Full Custom", self._interactive_full_custom, shortcut="s"),
+        ])
+
+    async def _interactive_status_update(self) -> None:
+        status: str = await utility.prompt_text("Which status?")
+        await self.action_status_update(status, {})
+
+    async def _interactive_full_custom(self) -> None:
+        raw: str = await utility.prompt_text("Enter full raw request:")
+        req_json = self.__raw_to_json(raw)
+        await self.by_device_req_send(req_json['id'], req_json)

--- a/src/charge_device_simulator/device/ocpp_enums.py
+++ b/src/charge_device_simulator/device/ocpp_enums.py
@@ -1,0 +1,94 @@
+"""Canonical OCPP enum value lists used by the interactive UI pickers.
+
+Hand-coded per the official OCPP 1.6 / 2.0.1 specs and the OCPP 1.5 SOAP WSDL
+(virta-ltd/charge-device-simulator/.../wsdl/server-201206.wsdl). Hand-coding
+keeps these usable when no WSDL is available (OCPP-J) and avoids parsing at
+runtime. If the spec adds a value, append it here — `select_from_list`
+also accepts custom input as a fallback.
+"""
+import typing
+
+# --- OCPP 1.6 (and structurally-identical OCPP-S 1.5/1.6 SOAP) -----------------
+
+OCPP_16_CONNECTOR_STATUSES: typing.Tuple[str, ...] = (
+    "Available",
+    "Preparing",
+    "Charging",
+    "SuspendedEVSE",
+    "SuspendedEV",
+    "Finishing",
+    "Reserved",
+    "Unavailable",
+    "Faulted",
+)
+
+OCPP_16_ERROR_CODES: typing.Tuple[str, ...] = (
+    "ConnectorLockFailure",
+    "EVCommunicationError",
+    "GroundFailure",
+    "HighTemperature",
+    "InternalError",
+    "LocalListConflict",
+    "NoError",
+    "OtherError",
+    "OverCurrentFailure",
+    "OverVoltage",
+    "PowerMeterFailure",
+    "PowerSwitchFailure",
+    "ReaderFailure",
+    "ResetFailure",
+    "UnderVoltage",
+    "WeakSignal",
+)
+
+OCPP_16_AVAILABILITY_TYPES: typing.Tuple[str, ...] = (
+    "Inoperative",
+    "Operative",
+)
+
+OCPP_16_RESET_TYPES: typing.Tuple[str, ...] = (
+    "Hard",
+    "Soft",
+)
+
+OCPP_16_CHARGING_PROFILE_PURPOSES: typing.Tuple[str, ...] = (
+    "ChargePointMaxProfile",
+    "TxDefaultProfile",
+    "TxProfile",
+)
+
+# --- OCPP 2.0.1 ----------------------------------------------------------------
+
+OCPP_201_CONNECTOR_STATUSES: typing.Tuple[str, ...] = (
+    "Available",
+    "Occupied",
+    "Reserved",
+    "Unavailable",
+    "Faulted",
+)
+
+OCPP_201_ID_TOKEN_TYPES: typing.Tuple[str, ...] = (
+    "Central",
+    "eMAID",
+    "ISO14443",
+    "ISO15693",
+    "KeyCode",
+    "Local",
+    "MacAddress",
+    "NoAuthorization",
+)
+
+OCPP_201_RESET_TYPES: typing.Tuple[str, ...] = (
+    "Immediate",
+    "OnIdle",
+)
+
+# --- OCPP 1.5/1.6 SOAP (Authorize) ---------------------------------------------
+
+OCPP_S_AUTHORIZATION_STATUSES: typing.Tuple[str, ...] = (
+    "Accepted",
+    "Blocked",
+    "Expired",
+    "Invalid",
+    "ConcurrentTx",
+)

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -166,9 +166,13 @@ class AbstractDeviceOcppJ(DeviceAbstract):
         if not await self.action_authorize(options):
             self.charge_in_progress = False
             return False
+        if not self._pre_charge_reservation_gate(options):
+            self.charge_in_progress = False
+            return False
         if not await self.action_charge_start(options):
             self.charge_in_progress = False
             return False
+        self._consume_reservation_if_used(options)
         if not await self.action_status_update("Preparing", options):
             self.charge_in_progress = False
             return False
@@ -270,8 +274,6 @@ class AbstractDeviceOcppJ(DeviceAbstract):
             "UnlockConnector",
             "UpdateFirmware",
             "SendLocalList",
-            "CancelReservation",
-            "ReserveNow",
             "Reset",
             "DataTransfer",
             "RequestStartTransaction",
@@ -339,6 +341,24 @@ class AbstractDeviceOcppJ(DeviceAbstract):
                 resp_payload["status"] = "Rejected"
             else:
                 next_async_task = utility.run_with_delay(self.flow_charge_stop(), 2)
+
+        if req_action == "ReserveNow".lower():
+            reserve_options = self._reserve_now_options_from_payload(req_payload)
+            if reserve_options.get("connectorId") is None:
+                resp_payload = {"status": "Rejected"}
+            elif not self.reserve_can_accept(reserve_options.get("connectorId")):
+                resp_payload = {"status": "Occupied"}
+            else:
+                resp_payload = {"status": "Accepted"}
+                next_async_task = utility.run_with_delay(self.flow_reserve(reserve_options), 2)
+
+        if req_action == "CancelReservation".lower():
+            reservation_id = req_payload.get("reservationId")
+            if not self.reserve_can_cancel(reservation_id):
+                resp_payload = {"status": "Rejected"}
+            else:
+                resp_payload = {"status": "Accepted"}
+                next_async_task = utility.run_with_delay(self.flow_reservation_cancel(reservation_id), 2)
 
         if req_action == "Reset".lower():
             next_async_task = utility.run_with_delay(self.re_initialize(), 2)

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -343,7 +343,7 @@ class AbstractDeviceOcppJ(DeviceAbstract):
                 next_async_task = utility.run_with_delay(self.flow_charge_stop(), 2)
 
         if req_action == "ReserveNow".lower():
-            reserve_options = self._reserve_now_options_from_payload(req_payload)
+            reserve_options: typing.Dict[str, typing.Any] = self._reserve_now_options_from_payload(req_payload)
             if reserve_options.get("connectorId") is None:
                 resp_payload = {"status": "Rejected"}
             elif not self.reserve_can_accept(reserve_options.get("connectorId")):
@@ -353,12 +353,13 @@ class AbstractDeviceOcppJ(DeviceAbstract):
                 next_async_task = utility.run_with_delay(self.flow_reserve(reserve_options), 2)
 
         if req_action == "CancelReservation".lower():
-            reservation_id = req_payload.get("reservationId")
-            if not self.reserve_can_cancel(reservation_id):
+            cancel_reservation_id: typing.Optional[int] = req_payload.get("reservationId")
+            if not self.reserve_can_cancel(cancel_reservation_id):
                 resp_payload = {"status": "Rejected"}
             else:
                 resp_payload = {"status": "Accepted"}
-                next_async_task = utility.run_with_delay(self.flow_reservation_cancel(reservation_id), 2)
+                next_async_task = utility.run_with_delay(
+                    self.flow_reservation_cancel(cancel_reservation_id), 2)
 
         if req_action == "Reset".lower():
             next_async_task = utility.run_with_delay(self.re_initialize(), 2)

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -163,6 +163,7 @@ class AbstractDeviceOcppJ(DeviceAbstract):
     async def flow_charge(self, auto_stop: bool, options: dict) -> bool:
         log_title = self.flow_charge.__name__
         self.logger.info(f"Flow {log_title} Start")
+        self._reset_charge_cycle_options(options)
         if not await self.action_authorize(options):
             self.charge_in_progress = False
             return False

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -1,4 +1,5 @@
 import sys
+import typing
 
 import aioconsole
 
@@ -75,7 +76,7 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
         if resp_json is None or len(resp_json) != 3 or resp_json[2][key_name]['status'] != 'Accepted':
             await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
             return False
-        id_tag_info = resp_json[2][key_name]
+        id_tag_info: typing.Dict[str, typing.Any] = resp_json[2][key_name]
         self._last_authorize_info = {
             "id_tag": id_tag,
             "parent_id_tag": id_tag_info.get("parentIdTag"),

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -1,9 +1,9 @@
 import sys
 import typing
 
-import aioconsole
-
+from .. import utility
 from ..error_reasons import ErrorReasons
+from ..ocpp_enums import OCPP_16_CONNECTOR_STATUSES, OCPP_16_ERROR_CODES
 from .abstract_device_ocpp_j import AbstractDeviceOcppJ
 
 if sys.platform != "win32":
@@ -153,29 +153,29 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
         return True
 
     async def loop_interactive_custom(self):
-        is_back = False
-        while not is_back:
-            input1 = await aioconsole.ainput(f"""
-What should I do? (enter the number + enter)
-0: Back
-1: HeartBeat
-2: StatusUpdate
-{self.interactive_reservation_menu}99: Full custom
-""")
-            if input1 == "0":
-                is_back = True
-            elif input1 == "1":
-                await self.action_heart_beat()
-            elif input1 == "2":
-                input1 = await aioconsole.ainput("Which status?\n")
-                input2 = await aioconsole.ainput("Which errorCode?\n")
-                input3 = await aioconsole.ainput("Which connector?\n")
-                await self.action_status_update_ocpp(input1, input2, {
-                    'connectorId': input3,
-                })
-            elif await self.interactive_reservation_handle(input1):
-                pass
-            elif input1 == "99":
-                input1 = input("Enter full custom message:\n")
-                await self.by_device_req_send_raw(input1, "Custom")
-        pass
+        await utility.run_menu("What should I do?", [
+            utility.MenuEntry("Back", is_back=True, shortcut="0"),
+            utility.MenuEntry("HeartBeat", self.action_heart_beat, shortcut="1"),
+            utility.MenuEntry("StatusUpdate", self._interactive_status_update, shortcut="2"),
+            utility.MenuEntry("Show reservation state",
+                              self.interactive_reservation_show, shortcut="3"),
+            utility.MenuEntry("Make reservation (simulate ReserveNow)",
+                              self.interactive_reservation_make, shortcut="4"),
+            utility.MenuEntry("Cancel reservation (simulate CancelReservation)",
+                              self.interactive_reservation_cancel, shortcut="5"),
+            utility.MenuEntry("Full custom", self._interactive_full_custom, shortcut="s"),
+        ])
+
+    async def _interactive_status_update(self) -> None:
+        status: str = await utility.select_from_list(
+            "Which status?", OCPP_16_CONNECTOR_STATUSES)
+        error_code: str = await utility.select_from_list(
+            "Which errorCode?", OCPP_16_ERROR_CODES)
+        connector: str = await utility.prompt_text("Which connector?")
+        await self.action_status_update_ocpp(status, error_code, {
+            'connectorId': connector,
+        })
+
+    async def _interactive_full_custom(self) -> None:
+        message: str = await utility.prompt_text("Enter full custom message:")
+        await self.by_device_req_send_raw(message, "Custom")

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import typing
 
@@ -42,7 +43,9 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
             json_payload['chargePointSerialNumber'] = self.spec_chargePointSerialNumber
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or resp_json[2]['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
+                ErrorReasons.InvalidResponse)
             return False
         self.logger.info(f"Action {action} End")
         return True
@@ -74,7 +77,9 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
         resp_json = await self.by_device_req_send(action, json_payload)
 
         if resp_json is None or len(resp_json) != 3 or resp_json[2][key_name]['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
+                ErrorReasons.InvalidResponse)
             return False
         id_tag_info: typing.Dict[str, typing.Any] = resp_json[2][key_name]
         self._last_authorize_info = {
@@ -101,7 +106,9 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
             json_payload["reservationId"] = options["reservationId"]
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or len(resp_json) != 3 or resp_json[2][key_name]['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
+                ErrorReasons.InvalidResponse)
             return False
         self.charge_id = resp_json[2]['transactionId']
         self.charge_in_progress = True
@@ -147,7 +154,9 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
         }
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or len(resp_json) != 3 or resp_json[2][key_name]['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
+                ErrorReasons.InvalidResponse)
             return False
         self.logger.info(f"Action {action} End")
         return True

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -75,6 +75,11 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
         if resp_json is None or len(resp_json) != 3 or resp_json[2][key_name]['status'] != 'Accepted':
             await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
             return False
+        id_tag_info = resp_json[2][key_name]
+        self._last_authorize_info = {
+            "id_tag": id_tag,
+            "parent_id_tag": id_tag_info.get("parentIdTag"),
+        }
         self.logger.info(f"Action {action} End")
         return True
 
@@ -91,6 +96,8 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
             "meterStart": options["meterStart"],
             "idTag": id_tag
         }
+        if "reservationId" in options:
+            json_payload["reservationId"] = options["reservationId"]
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or len(resp_json) != 3 or resp_json[2][key_name]['status'] != 'Accepted':
             await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
@@ -147,12 +154,12 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
     async def loop_interactive_custom(self):
         is_back = False
         while not is_back:
-            input1 = await aioconsole.ainput("""
+            input1 = await aioconsole.ainput(f"""
 What should I do? (enter the number + enter)
 0: Back
 1: HeartBeat
 2: StatusUpdate
-99: Full custom
+{self.interactive_reservation_menu}99: Full custom
 """)
             if input1 == "0":
                 is_back = True
@@ -165,6 +172,8 @@ What should I do? (enter the number + enter)
                 await self.action_status_update_ocpp(input1, input2, {
                     'connectorId': input3,
                 })
+            elif await self.interactive_reservation_handle(input1):
+                pass
             elif input1 == "99":
                 input1 = input("Enter full custom message:\n")
                 await self.by_device_req_send_raw(input1, "Custom")

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -250,6 +250,7 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
     async def flow_charge(self, auto_stop: bool, options: dict) -> bool:
         log_title = self.flow_charge.__name__
         self.logger.info(f"Flow {log_title} Start")
+        self._reset_charge_cycle_options(options)
         if not await self.action_authorize(options):
             self.charge_in_progress = False
             return False

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -3,9 +3,10 @@ import sys
 import typing
 import uuid
 
-import aioconsole
 from .abstract_device_ocpp_j import AbstractDeviceOcppJ
+from .. import utility
 from ..error_reasons import ErrorReasons
+from ..ocpp_enums import OCPP_201_CONNECTOR_STATUSES
 
 if sys.platform != "win32":
     # Fake call to readline module to make sure it is loaded
@@ -282,30 +283,29 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         }
 
     async def loop_interactive_custom(self):
-        is_back = False
-        while not is_back:
-            input1 = await aioconsole.ainput(f"""
-What should I do? (enter the number + enter)
-0: Back
-1: HeartBeat
-2: StatusUpdate
-{self.interactive_reservation_menu}99: Full custom
-""")
-            if input1 == "0":
-                is_back = True
-            elif input1 == "1":
-                await self.action_heart_beat()
-            elif input1 == "2":
-                input1 = await aioconsole.ainput("Which status?\n")
-                input2 = await aioconsole.ainput("Which evseId?\n")
-                input3 = await aioconsole.ainput("Which connector?\n")
-                await self.action_status_update_ocpp(input1, {
-                    'evseId': int(input2),
-                    'connectorId': int(input3),
-                })
-            elif await self.interactive_reservation_handle(input1):
-                pass
-            elif input1 == "99":
-                input1 = input("Enter full custom message:\n")
-                await self.by_device_req_send_raw(input1, "Custom")
-        pass
+        await utility.run_menu("What should I do?", [
+            utility.MenuEntry("Back", is_back=True, shortcut="0"),
+            utility.MenuEntry("HeartBeat", self.action_heart_beat, shortcut="1"),
+            utility.MenuEntry("StatusUpdate", self._interactive_status_update, shortcut="2"),
+            utility.MenuEntry("Show reservation state",
+                              self.interactive_reservation_show, shortcut="3"),
+            utility.MenuEntry("Make reservation (simulate ReserveNow)",
+                              self.interactive_reservation_make, shortcut="4"),
+            utility.MenuEntry("Cancel reservation (simulate CancelReservation)",
+                              self.interactive_reservation_cancel, shortcut="5"),
+            utility.MenuEntry("Full custom", self._interactive_full_custom, shortcut="s"),
+        ])
+
+    async def _interactive_status_update(self) -> None:
+        status: str = await utility.select_from_list(
+            "Which status?", OCPP_201_CONNECTOR_STATUSES)
+        evse_id: str = await utility.prompt_text("Which evseId?")
+        connector: str = await utility.prompt_text("Which connector?")
+        await self.action_status_update_ocpp(status, {
+            'evseId': int(evse_id),
+            'connectorId': int(connector),
+        })
+
+    async def _interactive_full_custom(self) -> None:
+        message: str = await utility.prompt_text("Enter full custom message:")
+        await self.by_device_req_send_raw(message, "Custom")

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -81,6 +81,12 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         if resp_json is None or resp_json[2][key_name]['status'] != 'Accepted':
             await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
             return False
+        id_token_info = resp_json[2][key_name]
+        group_id_token = id_token_info.get("groupIdToken") or {}
+        self._last_authorize_info = {
+            "id_tag": id_tag,
+            "parent_id_tag": group_id_token.get("idToken"),
+        }
         self.logger.info(f"Action {action} End")
         return True
 
@@ -102,6 +108,7 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
                 "transactionId": transaction_id,
                 "chargingState":"Idle"
             },
+            **({"reservationId": options["reservationId"]} if "reservationId" in options else {}),
             "meterValue":[
                 {
                     "sampledValue": [
@@ -235,12 +242,16 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         if not await self.action_authorize(options):
             self.charge_in_progress = False
             return False
+        if not self._pre_charge_reservation_gate(options):
+            self.charge_in_progress = False
+            return False
         if not await self.action_status_update("Occupied", options):
             self.charge_in_progress = False
             return False
         if not await self.action_charge_start(options):
             self.charge_in_progress = False
             return False
+        self._consume_reservation_if_used(options)
         if not await self.flow_charge_ongoing_loop(auto_stop, options):
             self.charge_in_progress = False
             return False
@@ -254,15 +265,28 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         self.charge_in_progress = False
         return True
 
+    def _reserve_now_options_from_payload(self, req_payload: dict) -> dict:
+        id_token = req_payload.get("idToken") or {}
+        group_id_token = req_payload.get("groupIdToken") or {}
+        evse_id = req_payload.get("evseId")
+        return {
+            "reservationId": req_payload.get("id"),
+            "connectorId": evse_id if evse_id is not None else 1,
+            "evseId": evse_id if evse_id is not None else 1,
+            "idTag": id_token.get("idToken"),
+            "parentIdTag": group_id_token.get("idToken"),
+            "expiryDate": req_payload.get("expiryDateTime"),
+        }
+
     async def loop_interactive_custom(self):
         is_back = False
         while not is_back:
-            input1 = await aioconsole.ainput("""
+            input1 = await aioconsole.ainput(f"""
 What should I do? (enter the number + enter)
 0: Back
 1: HeartBeat
 2: StatusUpdate
-99: Full custom
+{self.interactive_reservation_menu}99: Full custom
 """)
             if input1 == "0":
                 is_back = True
@@ -276,6 +300,8 @@ What should I do? (enter the number + enter)
                     'evseId': int(input2),
                     'connectorId': int(input3),
                 })
+            elif await self.interactive_reservation_handle(input1):
+                pass
             elif input1 == "99":
                 input1 = input("Enter full custom message:\n")
                 await self.by_device_req_send_raw(input1, "Custom")

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import sys
 import typing
 import uuid
@@ -45,7 +46,9 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
             json_payload['chargingStation']['modem']['imsi'] = self.spec_imsi
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or resp_json[2]['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
+                ErrorReasons.InvalidResponse)
             return False
         self.logger.info(f"Action {action} End")
         return True
@@ -81,7 +84,9 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         resp_json = await self.by_device_req_send(action, json_payload)
 
         if resp_json is None or resp_json[2][key_name]['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
+                ErrorReasons.InvalidResponse)
             return False
         id_token_info: typing.Dict[str, typing.Any] = resp_json[2][key_name]
         group_id_token: typing.Dict[str, typing.Any] = id_token_info.get("groupIdToken") or {}
@@ -137,7 +142,9 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         key_name = "idTokenInfo"
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or resp_json[2][key_name]['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
+                ErrorReasons.InvalidResponse)
             return False
         self.charge_id = transaction_id
         self.charge_in_progress = True
@@ -233,7 +240,9 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         }
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or resp_json[2][key_name]['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
+                ErrorReasons.InvalidResponse)
             return False
         self.logger.info(f"Action {action} End")
         return True

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -1,5 +1,6 @@
 import datetime
 import sys
+import typing
 import uuid
 
 import aioconsole
@@ -81,8 +82,8 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         if resp_json is None or resp_json[2][key_name]['status'] != 'Accepted':
             await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
             return False
-        id_token_info = resp_json[2][key_name]
-        group_id_token = id_token_info.get("groupIdToken") or {}
+        id_token_info: typing.Dict[str, typing.Any] = resp_json[2][key_name]
+        group_id_token: typing.Dict[str, typing.Any] = id_token_info.get("groupIdToken") or {}
         self._last_authorize_info = {
             "id_tag": id_tag,
             "parent_id_tag": group_id_token.get("idToken"),
@@ -265,10 +266,12 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
         self.charge_in_progress = False
         return True
 
-    def _reserve_now_options_from_payload(self, req_payload: dict) -> dict:
-        id_token = req_payload.get("idToken") or {}
-        group_id_token = req_payload.get("groupIdToken") or {}
-        evse_id = req_payload.get("evseId")
+    def _reserve_now_options_from_payload(
+        self, req_payload: typing.Dict[str, typing.Any],
+    ) -> typing.Dict[str, typing.Any]:
+        id_token: typing.Dict[str, typing.Any] = req_payload.get("idToken") or {}
+        group_id_token: typing.Dict[str, typing.Any] = req_payload.get("groupIdToken") or {}
+        evse_id: typing.Optional[int] = req_payload.get("evseId")
         return {
             "reservationId": req_payload.get("id"),
             "connectorId": evse_id if evse_id is not None else 1,

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -164,7 +164,7 @@ class DeviceOcppS(DeviceAbstract):
             return False
         # Per the OCPP 1.5/1.6 SOAP schema, parentIdTag lives inside idTagInfo.
         # Fall back to the top level for tolerance with non-standard responses.
-        def _lookup(obj, key):
+        def _lookup(obj: typing.Any, key: str) -> typing.Any:
             if obj is None:
                 return None
             if hasattr(obj, "get"):
@@ -174,8 +174,8 @@ class DeviceOcppS(DeviceAbstract):
                     return None
             return getattr(obj, key, None)
 
-        info = _lookup(resp_payload, "idTagInfo") or resp_payload
-        parent_id_tag = _lookup(info, "parentIdTag")
+        info: typing.Any = _lookup(resp_payload, "idTagInfo") or resp_payload
+        parent_id_tag: typing.Optional[str] = _lookup(info, "parentIdTag")
         self._last_authorize_info = {
             "id_tag": id_tag,
             "parent_id_tag": parent_id_tag,
@@ -398,7 +398,7 @@ class DeviceOcppS(DeviceAbstract):
                 asyncio.create_task(utility.run_with_delay(self.flow_charge_stop(), 2))
 
         if req_action == "ReserveNow".lower():
-            reserve_options = self._reserve_now_options_from_payload(req_payload)
+            reserve_options: typing.Dict[str, typing.Any] = self._reserve_now_options_from_payload(req_payload)
             if reserve_options.get("connectorId") is None:
                 resp_payload = {"status": "Rejected"}
             elif not self.reserve_can_accept(reserve_options.get("connectorId")):
@@ -408,12 +408,13 @@ class DeviceOcppS(DeviceAbstract):
                 asyncio.create_task(utility.run_with_delay(self.flow_reserve(reserve_options), 2))
 
         if req_action == "CancelReservation".lower():
-            reservation_id = req_payload.get("reservationId")
-            if not self.reserve_can_cancel(reservation_id):
+            cancel_reservation_id: typing.Optional[int] = req_payload.get("reservationId")
+            if not self.reserve_can_cancel(cancel_reservation_id):
                 resp_payload = {"status": "Rejected"}
             else:
                 resp_payload = {"status": "Accepted"}
-                asyncio.create_task(utility.run_with_delay(self.flow_reservation_cancel(reservation_id), 2))
+                asyncio.create_task(utility.run_with_delay(
+                    self.flow_reservation_cancel(cancel_reservation_id), 2))
 
         if req_action == "Reset".lower():
             asyncio.create_task(utility.run_with_delay(self.re_initialize(), 2))

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -7,10 +7,10 @@ import os
 import typing
 import uuid
 
-import aioconsole
 from .. import utility
 from ..abstract import DeviceAbstract
 from ..error_reasons import ErrorReasons
+from ..ocpp_enums import OCPP_16_CONNECTOR_STATUSES, OCPP_16_ERROR_CODES
 from ..ocpp_j.message_types import MessageTypes
 from .wsa_extension_plugin import WsAddressingExtensionPlugin
 from ...model.error_message import ErrorMessage
@@ -426,30 +426,30 @@ class DeviceOcppS(DeviceAbstract):
         pass
 
     async def loop_interactive_custom(self):
-        is_back = False
-        while not is_back:
-            input1 = await aioconsole.ainput(f"""
-What should I do? (enter the number + enter)
-0: Back
-1: HeartBeat
-2: StatusUpdate
-{self.interactive_reservation_menu}99: Full custom
-""")
-            if input1 == "0":
-                is_back = True
-            elif input1 == "1":
-                await self.action_heart_beat()
-            elif input1 == "2":
-                input1 = await aioconsole.ainput("Which status?\n")
-                input2 = await aioconsole.ainput("Which errorCode?\n")
-                input3 = await aioconsole.ainput("Which connector?\n")
-                await self.action_status_update_ocpp(input1, input2, {
-                    'connectorId': input3,
-                })
-            elif await self.interactive_reservation_handle(input1):
-                pass
-            elif input1 == "99":
-                input_action = await aioconsole.ainput("Enter full custom action name:\n")
-                input_payload = await aioconsole.ainput("Enter full custom payload:\n")
-                await self.by_device_req_send_raw(json.loads(input_payload), input_action)
-        pass
+        await utility.run_menu("What should I do?", [
+            utility.MenuEntry("Back", is_back=True, shortcut="0"),
+            utility.MenuEntry("HeartBeat", self.action_heart_beat, shortcut="1"),
+            utility.MenuEntry("StatusUpdate", self._interactive_status_update, shortcut="2"),
+            utility.MenuEntry("Show reservation state",
+                              self.interactive_reservation_show, shortcut="3"),
+            utility.MenuEntry("Make reservation (simulate ReserveNow)",
+                              self.interactive_reservation_make, shortcut="4"),
+            utility.MenuEntry("Cancel reservation (simulate CancelReservation)",
+                              self.interactive_reservation_cancel, shortcut="5"),
+            utility.MenuEntry("Full custom", self._interactive_full_custom, shortcut="s"),
+        ])
+
+    async def _interactive_status_update(self) -> None:
+        status: str = await utility.select_from_list(
+            "Which status?", OCPP_16_CONNECTOR_STATUSES)
+        error_code: str = await utility.select_from_list(
+            "Which errorCode?", OCPP_16_ERROR_CODES)
+        connector: str = await utility.prompt_text("Which connector?")
+        await self.action_status_update_ocpp(status, error_code, {
+            'connectorId': connector,
+        })
+
+    async def _interactive_full_custom(self) -> None:
+        input_action: str = await utility.prompt_text("Enter full custom action name:")
+        input_payload: str = await utility.prompt_text("Enter full custom payload:")
+        await self.by_device_req_send_raw(json.loads(input_payload), input_action)

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -302,6 +302,7 @@ class DeviceOcppS(DeviceAbstract):
     async def flow_charge(self, auto_stop: bool, options: dict) -> bool:
         log_title = self.flow_charge.__name__
         self.logger.info(f"Flow {log_title} Start")
+        self._reset_charge_cycle_options(options)
         if not await self.action_authorize(options):
             self.charge_in_progress = False
             return False

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -154,13 +154,32 @@ class DeviceOcppS(DeviceAbstract):
     async def action_authorize(self, options: dict) -> bool:
         action = "Authorize"
         self.logger.info(f"Action {action} Start")
+        id_tag = options.get("idTag", "-")
         req_payload = {
-            "idTag": options.get("idTag", "-")
+            "idTag": id_tag
         }
         resp_payload = await self.by_device_req_send(action, req_payload)
         if resp_payload is None or resp_payload['status'] != 'Accepted':
             await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
             return False
+        # Per the OCPP 1.5/1.6 SOAP schema, parentIdTag lives inside idTagInfo.
+        # Fall back to the top level for tolerance with non-standard responses.
+        def _lookup(obj, key):
+            if obj is None:
+                return None
+            if hasattr(obj, "get"):
+                try:
+                    return obj.get(key)
+                except Exception:
+                    return None
+            return getattr(obj, key, None)
+
+        info = _lookup(resp_payload, "idTagInfo") or resp_payload
+        parent_id_tag = _lookup(info, "parentIdTag")
+        self._last_authorize_info = {
+            "id_tag": id_tag,
+            "parent_id_tag": parent_id_tag,
+        }
         self.logger.info(f"Action {action} End")
         return True
 
@@ -196,6 +215,8 @@ class DeviceOcppS(DeviceAbstract):
             "meterStart": options["meterStart"],
             "idTag": options.get("idTag", "-")
         }
+        if "reservationId" in options:
+            req_payload["reservationId"] = options["reservationId"]
         resp_payload = await self.by_device_req_send(action, req_payload)
         if resp_payload is None or resp_payload['idTagInfo']['status'] != 'Accepted':
             await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
@@ -276,9 +297,13 @@ class DeviceOcppS(DeviceAbstract):
         if not await self.action_authorize(options):
             self.charge_in_progress = False
             return False
+        if not self._pre_charge_reservation_gate(options):
+            self.charge_in_progress = False
+            return False
         if not await self.action_charge_start(options):
             self.charge_in_progress = False
             return False
+        self._consume_reservation_if_used(options)
         if not await self.action_status_update("Preparing", options):
             self.charge_in_progress = False
             return False
@@ -336,8 +361,6 @@ class DeviceOcppS(DeviceAbstract):
             "UnlockConnector",
             "UpdateFirmware",
             "SendLocalList",
-            "CancelReservation",
-            "ReserveNow",
             "Reset",
             "DataTransfer",
         ]):
@@ -374,6 +397,24 @@ class DeviceOcppS(DeviceAbstract):
             else:
                 asyncio.create_task(utility.run_with_delay(self.flow_charge_stop(), 2))
 
+        if req_action == "ReserveNow".lower():
+            reserve_options = self._reserve_now_options_from_payload(req_payload)
+            if reserve_options.get("connectorId") is None:
+                resp_payload = {"status": "Rejected"}
+            elif not self.reserve_can_accept(reserve_options.get("connectorId")):
+                resp_payload = {"status": "Occupied"}
+            else:
+                resp_payload = {"status": "Accepted"}
+                asyncio.create_task(utility.run_with_delay(self.flow_reserve(reserve_options), 2))
+
+        if req_action == "CancelReservation".lower():
+            reservation_id = req_payload.get("reservationId")
+            if not self.reserve_can_cancel(reservation_id):
+                resp_payload = {"status": "Rejected"}
+            else:
+                resp_payload = {"status": "Accepted"}
+                asyncio.create_task(utility.run_with_delay(self.flow_reservation_cancel(reservation_id), 2))
+
         if req_action == "Reset".lower():
             asyncio.create_task(utility.run_with_delay(self.re_initialize(), 2))
 
@@ -386,12 +427,12 @@ class DeviceOcppS(DeviceAbstract):
     async def loop_interactive_custom(self):
         is_back = False
         while not is_back:
-            input1 = await aioconsole.ainput("""
+            input1 = await aioconsole.ainput(f"""
 What should I do? (enter the number + enter)
 0: Back
 1: HeartBeat
 2: StatusUpdate
-99: Full custom
+{self.interactive_reservation_menu}99: Full custom
 """)
             if input1 == "0":
                 is_back = True
@@ -404,6 +445,8 @@ What should I do? (enter the number + enter)
                 await self.action_status_update_ocpp(input1, input2, {
                     'connectorId': input3,
                 })
+            elif await self.interactive_reservation_handle(input1):
+                pass
             elif input1 == "99":
                 input_action = await aioconsole.ainput("Enter full custom action name:\n")
                 input_payload = await aioconsole.ainput("Enter full custom payload:\n")

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -120,7 +120,9 @@ class DeviceOcppS(DeviceAbstract):
             req_payload['chargePointSerialNumber'] = self.spec_chargePointSerialNumber
         resp_payload = await self.by_device_req_send(action, req_payload)
         if resp_payload is None or resp_payload['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{resp_payload!r}",
+                ErrorReasons.InvalidResponse)
             return False
         self.logger.info(f"Action {action} End")
         return True
@@ -160,7 +162,9 @@ class DeviceOcppS(DeviceAbstract):
         }
         resp_payload = await self.by_device_req_send(action, req_payload)
         if resp_payload is None or resp_payload['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{resp_payload!r}",
+                ErrorReasons.InvalidResponse)
             return False
         # Per the OCPP 1.5/1.6 SOAP schema, parentIdTag lives inside idTagInfo.
         # Fall back to the top level for tolerance with non-standard responses.
@@ -219,7 +223,9 @@ class DeviceOcppS(DeviceAbstract):
             req_payload["reservationId"] = options["reservationId"]
         resp_payload = await self.by_device_req_send(action, req_payload)
         if resp_payload is None or resp_payload['idTagInfo']['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{resp_payload!r}",
+                ErrorReasons.InvalidResponse)
             return False
         self.charge_id = resp_payload['transactionId']
         self.charge_in_progress = True
@@ -270,7 +276,9 @@ class DeviceOcppS(DeviceAbstract):
         }
         resp_payload = await self.by_device_req_send(action, req_payload)
         if resp_payload is None or resp_payload['status'] != 'Accepted':
-            await self.handle_error(f"Action {action} Response Failed", ErrorReasons.InvalidResponse)
+            await self.handle_error(
+                f"Action {action} Response Failed:\n{resp_payload!r}",
+                ErrorReasons.InvalidResponse)
             return False
         self.logger.info(f"Action {action} End")
         return True

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -107,6 +107,12 @@ class Simulator:
         pass
 
     async def lifecycle_start(self):
+        # Interactive sessions should drop back to the menu on a rejected
+        # response instead of sys.exit'ing the process. Toggled here (rather
+        # than in initialize) so callers can flip is_interactive after
+        # initialize() completes; common pattern in play_ground.py.
+        if self.is_interactive:
+            self.device.error_exit = False
         tasks = []
         if self.is_interactive:
             tasks.append(self.loop_interactive())

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -131,19 +131,26 @@ class Simulator:
             utility.MenuEntry("Flow charge", self._interactive_flow_charge, shortcut="1"),
             utility.MenuEntry("Flow heartbeat", self.device.flow_heartbeat, shortcut="2"),
             utility.MenuEntry("Flow authorize", self._interactive_flow_authorize, shortcut="3"),
-            utility.MenuEntry("Flow charge with RFID swipe",
-                              self._interactive_flow_rfid_swipe, shortcut="4"),
             utility.MenuEntry("Single message", self.device.loop_interactive_custom, shortcut="s"),
         ])
 
     async def _interactive_flow_charge(self) -> None:
-        await self.device.flow_charge(True, self.flow_charge_options)
+        options = await self._prompt_options_with_id_tag()
+        await self.device.flow_charge(True, options)
 
     async def _interactive_flow_authorize(self) -> None:
-        await self.device.flow_authorize(self.flow_charge_options)
+        options = await self._prompt_options_with_id_tag()
+        await self.device.flow_authorize(options)
 
-    async def _interactive_flow_rfid_swipe(self) -> None:
-        swiped_id_tag: str = await utility.prompt_text("Swipe RFID — enter idTag:")
-        swipe_options: typing.Dict[str, typing.Any] = dict(self.flow_charge_options)
-        swipe_options["idTag"] = swiped_id_tag
-        await self.device.flow_charge(True, swipe_options)
+    async def _prompt_options_with_id_tag(self) -> typing.Dict[str, typing.Any]:
+        """Prompt for an idTag, defaulting to the configured one. Returns the
+        stored options dict unchanged when the operator keeps the default
+        (preserves identity for any subsequent state mutation by actions); a
+        shallow copy with the override otherwise."""
+        default_id_tag: str = self.flow_charge_options.get("idTag", "")
+        chosen: str = await utility.prompt_text("idTag", default=default_id_tag)
+        if chosen == default_id_tag:
+            return self.flow_charge_options
+        options: typing.Dict[str, typing.Any] = dict(self.flow_charge_options)
+        options["idTag"] = chosen
+        return options

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -108,11 +108,14 @@ class Simulator:
 
     async def lifecycle_start(self):
         # Interactive sessions should drop back to the menu on a rejected
-        # response instead of sys.exit'ing the process. Toggled here (rather
-        # than in initialize) so callers can flip is_interactive after
-        # initialize() completes; common pattern in play_ground.py.
+        # response instead of sys.exit'ing the process, and need a few UX-only
+        # tweaks gated by `interactive_mode` (e.g. per-cycle option resets).
+        # Toggled here (rather than in initialize) so callers can flip
+        # is_interactive after initialize() completes; common pattern in
+        # play_ground.py.
         if self.is_interactive:
             self.device.error_exit = False
+            self.device.interactive_mode = True
         tasks = []
         if self.is_interactive:
             tasks.append(self.loop_interactive())

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -140,8 +140,8 @@ What should I do? (enter the number + enter)
             elif input1 == "3":
                 await self.device.flow_authorize(self.flow_charge_options)
             elif input1 == "4":
-                swiped_id_tag = await aioconsole.ainput("Swipe RFID — enter idTag:\n")
-                swipe_options = dict(self.flow_charge_options)
+                swiped_id_tag: str = await aioconsole.ainput("Swipe RFID — enter idTag:\n")
+                swipe_options: typing.Dict[str, typing.Any] = dict(self.flow_charge_options)
                 swipe_options["idTag"] = swiped_id_tag
                 await self.device.flow_charge(True, swipe_options)
             elif input1 == "99":

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -128,6 +128,7 @@ What should I do? (enter the number + enter)
 1: Flow charge
 2: Flow heartbeat
 3: Flow authorize
+4: Flow charge with RFID swipe (enter idTag)
 99: Single message
 """)
             if input1 == "0":
@@ -138,6 +139,11 @@ What should I do? (enter the number + enter)
                 await self.device.flow_heartbeat()
             elif input1 == "3":
                 await self.device.flow_authorize(self.flow_charge_options)
+            elif input1 == "4":
+                swiped_id_tag = await aioconsole.ainput("Swipe RFID — enter idTag:\n")
+                swipe_options = dict(self.flow_charge_options)
+                swipe_options["idTag"] = swiped_id_tag
+                await self.device.flow_charge(True, swipe_options)
             elif input1 == "99":
                 await self.device.loop_interactive_custom()
         pass

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -2,8 +2,7 @@ import asyncio
 import logging
 import typing
 
-import aioconsole
-
+from . import utility
 from .error_reasons import ErrorReasons
 from ..model.error_message import ErrorMessage
 from .abstract import DeviceAbstract
@@ -121,29 +120,24 @@ class Simulator:
         pass
 
     async def loop_interactive(self):
-        while not self.is_ended:
-            input1 = await aioconsole.ainput("""
-What should I do? (enter the number + enter)
-0: Exit
-1: Flow charge
-2: Flow heartbeat
-3: Flow authorize
-4: Flow charge with RFID swipe (enter idTag)
-99: Single message
-""")
-            if input1 == "0":
-                return
-            elif input1 == "1":
-                await self.device.flow_charge(True, self.flow_charge_options)
-            elif input1 == "2":
-                await self.device.flow_heartbeat()
-            elif input1 == "3":
-                await self.device.flow_authorize(self.flow_charge_options)
-            elif input1 == "4":
-                swiped_id_tag: str = await aioconsole.ainput("Swipe RFID — enter idTag:\n")
-                swipe_options: typing.Dict[str, typing.Any] = dict(self.flow_charge_options)
-                swipe_options["idTag"] = swiped_id_tag
-                await self.device.flow_charge(True, swipe_options)
-            elif input1 == "99":
-                await self.device.loop_interactive_custom()
-        pass
+        await utility.run_menu("What should I do?", [
+            utility.MenuEntry("Exit", is_back=True, shortcut="0"),
+            utility.MenuEntry("Flow charge", self._interactive_flow_charge, shortcut="1"),
+            utility.MenuEntry("Flow heartbeat", self.device.flow_heartbeat, shortcut="2"),
+            utility.MenuEntry("Flow authorize", self._interactive_flow_authorize, shortcut="3"),
+            utility.MenuEntry("Flow charge with RFID swipe",
+                              self._interactive_flow_rfid_swipe, shortcut="4"),
+            utility.MenuEntry("Single message", self.device.loop_interactive_custom, shortcut="s"),
+        ])
+
+    async def _interactive_flow_charge(self) -> None:
+        await self.device.flow_charge(True, self.flow_charge_options)
+
+    async def _interactive_flow_authorize(self) -> None:
+        await self.device.flow_authorize(self.flow_charge_options)
+
+    async def _interactive_flow_rfid_swipe(self) -> None:
+        swiped_id_tag: str = await utility.prompt_text("Swipe RFID — enter idTag:")
+        swipe_options: typing.Dict[str, typing.Any] = dict(self.flow_charge_options)
+        swipe_options["idTag"] = swiped_id_tag
+        await self.device.flow_charge(True, swipe_options)

--- a/src/charge_device_simulator/device/utility.py
+++ b/src/charge_device_simulator/device/utility.py
@@ -5,6 +5,7 @@ import typing
 
 import aioconsole
 import questionary
+from prompt_toolkit.patch_stdout import patch_stdout
 
 
 async def run_with_delay(to_run, delay_seconds):
@@ -114,12 +115,15 @@ async def _select_tty(
     # `use_shortcuts=True` is required for shortcuts to render and bind at all.
     # Questionary leaves explicit `shortcut_key` values alone and only
     # auto-assigns 1..9 to choices that don't have one.
-    result: typing.Optional[str] = await questionary.select(
-        prompt,
-        choices=full_choices,
-        default=default if default in choices else None,
-        use_shortcuts=True,
-    ).ask_async()
+    # `patch_stdout` keeps background log output above the prompt so the menu
+    # re-renders cleanly underneath instead of scrolling off-screen.
+    with patch_stdout(raw=True):
+        result: typing.Optional[str] = await questionary.select(
+            prompt,
+            choices=full_choices,
+            default=default if default in choices else None,
+            use_shortcuts=True,
+        ).ask_async()
     if result is None:
         # User aborted (Ctrl-C); re-raise as cancellation.
         raise asyncio.CancelledError()
@@ -140,10 +144,11 @@ async def prompt_text(prompt: str, *, default: typing.Optional[str] = None) -> s
     """
     if _is_tty():
         try:
-            result: typing.Optional[str] = await questionary.text(
-                prompt,
-                default=default or "",
-            ).ask_async()
+            with patch_stdout(raw=True):
+                result: typing.Optional[str] = await questionary.text(
+                    prompt,
+                    default=default or "",
+                ).ask_async()
             if result is None:
                 raise asyncio.CancelledError()
             return result

--- a/src/charge_device_simulator/device/utility.py
+++ b/src/charge_device_simulator/device/utility.py
@@ -1,7 +1,201 @@
 import asyncio
+import dataclasses
+import sys
+import typing
+
+import aioconsole
+import questionary
 
 
 async def run_with_delay(to_run, delay_seconds):
     await asyncio.sleep(delay_seconds)
     await to_run
     pass
+
+
+@dataclasses.dataclass
+class MenuEntry:
+    """A single entry in an interactive menu. `handler` is awaited when the
+    entry is selected; `is_back` flags the entry that exits the loop;
+    `shortcut` (single character) is the keyboard accelerator in TTY mode and
+    is also accepted as input on the non-TTY fallback path."""
+    label: str
+    handler: typing.Optional[typing.Callable[[], typing.Awaitable[typing.Any]]] = None
+    is_back: bool = False
+    shortcut: typing.Optional[str] = None
+
+
+async def run_menu(prompt: str, entries: typing.Sequence[MenuEntry]) -> None:
+    """Loop the menu: select an entry, dispatch its handler, repeat until an
+    `is_back` entry is chosen. Selection runs through `select_from_list`, so
+    it gets arrow-key + numeric/letter shortcuts in TTY and a numbered-list
+    fallback elsewhere."""
+    labels: typing.List[str] = [e.label for e in entries]
+    shortcuts: typing.List[typing.Optional[str]] = [e.shortcut for e in entries]
+    while True:
+        choice: str = await select_from_list(
+            prompt, labels, allow_custom=False, shortcuts=shortcuts)
+        entry: MenuEntry = next(e for e in entries if e.label == choice)
+        if entry.is_back:
+            return
+        if entry.handler is not None:
+            await entry.handler()
+
+
+_OTHER_SENTINEL: str = "Other (enter custom value)"
+
+
+def _is_tty() -> bool:
+    """True when stdin is attached to a real terminal. False under pytest,
+    piped input, or any environment where prompt_toolkit can't render."""
+    try:
+        return sys.stdin.isatty()
+    except Exception:
+        return False
+
+
+async def select_from_list(
+    prompt: str,
+    choices: typing.Sequence[str],
+    *,
+    default: typing.Optional[str] = None,
+    allow_custom: bool = True,
+    shortcuts: typing.Optional[typing.Sequence[typing.Optional[str]]] = None,
+) -> str:
+    """Pick one of `choices` interactively.
+
+    TTY: questionary's arrow-key picker. If `shortcuts` is provided, each
+    choice carries that explicit shortcut key; otherwise questionary
+    auto-assigns 1..9. If `allow_custom`, an "Other" sentinel is appended.
+
+    Non-TTY (pytest, piped input): a numbered list is printed and one line is
+    read. A numeric index resolves to that choice; a literal match returns
+    that choice; a shortcut match resolves to the corresponding choice;
+    otherwise the input is returned verbatim when `allow_custom`, else the
+    prompt repeats. Empty input + `default` returns `default`.
+    """
+    if shortcuts is not None and len(shortcuts) != len(choices):
+        raise ValueError("shortcuts must match the length of choices")
+    if _is_tty():
+        try:
+            return await _select_tty(prompt, choices, default, allow_custom, shortcuts)
+        except Exception:
+            # Fall back to the line-based path on any prompt_toolkit failure
+            # (e.g., unsupported pseudo-terminal).
+            pass
+    return await _select_fallback(prompt, choices, default, allow_custom, shortcuts)
+
+
+def _build_questionary_choices(
+    choices: typing.Sequence[str],
+    shortcuts: typing.Optional[typing.Sequence[typing.Optional[str]]],
+) -> typing.List[typing.Any]:
+    if shortcuts is None:
+        return list(choices)
+    return [
+        questionary.Choice(title=label, value=label, shortcut_key=shortcut)
+        if shortcut is not None
+        else questionary.Choice(title=label, value=label)
+        for label, shortcut in zip(choices, shortcuts)
+    ]
+
+
+async def _select_tty(
+    prompt: str,
+    choices: typing.Sequence[str],
+    default: typing.Optional[str],
+    allow_custom: bool,
+    shortcuts: typing.Optional[typing.Sequence[typing.Optional[str]]],
+) -> str:
+    full_choices: typing.List[typing.Any] = _build_questionary_choices(choices, shortcuts)
+    if allow_custom:
+        full_choices.append(questionary.Separator())
+        full_choices.append(_OTHER_SENTINEL)
+    # `use_shortcuts=True` is required for shortcuts to render and bind at all.
+    # Questionary leaves explicit `shortcut_key` values alone and only
+    # auto-assigns 1..9 to choices that don't have one.
+    result: typing.Optional[str] = await questionary.select(
+        prompt,
+        choices=full_choices,
+        default=default if default in choices else None,
+        use_shortcuts=True,
+    ).ask_async()
+    if result is None:
+        # User aborted (Ctrl-C); re-raise as cancellation.
+        raise asyncio.CancelledError()
+    if result == _OTHER_SENTINEL:
+        return await prompt_text("Custom value:")
+    return result
+
+
+async def prompt_text(prompt: str, *, default: typing.Optional[str] = None) -> str:
+    """Read a free-form text line from the user.
+
+    TTY: questionary.text — keeps stdin under prompt_toolkit, so it composes
+    cleanly with prior `select_from_list` calls (a plain `aioconsole.ainput`
+    after a questionary picker can hang because prompt_toolkit briefly held
+    stdin in raw mode).
+
+    Non-TTY: aioconsole.ainput, same behavior as before.
+    """
+    if _is_tty():
+        try:
+            result: typing.Optional[str] = await questionary.text(
+                prompt,
+                default=default or "",
+            ).ask_async()
+            if result is None:
+                raise asyncio.CancelledError()
+            return result
+        except Exception:
+            pass
+    rendered: str = prompt
+    if default is not None:
+        rendered += f" [{default}]"
+    rendered += " "
+    raw: str = await aioconsole.ainput(rendered)
+    if raw == "" and default is not None:
+        return default
+    return raw
+
+
+async def _select_fallback(
+    prompt: str,
+    choices: typing.Sequence[str],
+    default: typing.Optional[str],
+    allow_custom: bool,
+    shortcuts: typing.Optional[typing.Sequence[typing.Optional[str]]],
+) -> str:
+    shortcut_to_choice: typing.Dict[str, str] = {}
+    if shortcuts is not None:
+        for label, shortcut in zip(choices, shortcuts):
+            if shortcut is not None:
+                shortcut_to_choice[shortcut] = label
+    while True:
+        rendered: str = prompt + "\n"
+        for idx, choice in enumerate(choices):
+            short: typing.Optional[str] = (
+                shortcuts[idx] if shortcuts is not None else None)
+            tag: str = f"({short})" if short is not None else f"{idx}"
+            rendered += f"  {tag}: {choice}\n"
+        if default is not None:
+            rendered += f"Pick an index, type a value, or press Enter for {default!r}: "
+        else:
+            rendered += "Pick an index or type a value: "
+        raw: str = await aioconsole.ainput(rendered)
+        if raw == "":
+            if default is not None:
+                return default
+            continue
+        if raw in shortcut_to_choice:
+            return shortcut_to_choice[raw]
+        if raw.isdigit():
+            index: int = int(raw)
+            if 0 <= index < len(choices):
+                return choices[index]
+        if raw in choices:
+            return raw
+        if allow_custom:
+            return raw
+        # Strict mode: re-prompt
+        print(f"Invalid value: {raw!r}. Pick from the list above.")

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -376,31 +376,24 @@ class TestConsumeReservationIfUsed:
         assert ocpp_j_device.reservation_id == 99
 
 
-class TestInteractiveReservationHandle:
+class TestInteractiveReservationHandlers:
     @pytest.mark.asyncio
-    async def test_show_state_returns_true_without_side_effects(self, ocpp_j_device):
+    async def test_show_state_does_not_invoke_flows(self, ocpp_j_device):
         _seed_reservation(ocpp_j_device, reservation_id=42)
         ocpp_j_device.flow_reserve = AsyncMock()
         ocpp_j_device.flow_reservation_cancel = AsyncMock()
 
-        result = await ocpp_j_device.interactive_reservation_handle("3")
+        await ocpp_j_device.interactive_reservation_show()
 
-        assert result is True
-        # No reservation flows are kicked off by "show state"
         ocpp_j_device.flow_reserve.assert_not_awaited()
         ocpp_j_device.flow_reservation_cancel.assert_not_awaited()
-        # State unchanged
         assert ocpp_j_device.reservation_id == 42
-
-    @pytest.mark.asyncio
-    async def test_unknown_input_returns_false(self, ocpp_j_device):
-        assert await ocpp_j_device.interactive_reservation_handle("99") is False
-        assert await ocpp_j_device.interactive_reservation_handle("0") is False
 
     @pytest.mark.asyncio
     async def test_make_reservation_collects_inputs_and_invokes_flow(self, ocpp_j_device):
         ocpp_j_device.flow_reserve = AsyncMock(return_value=True)
-        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input, \
+             patch("charge_device_simulator.device.utility._is_tty", return_value=False):
             mock_input.side_effect = [
                 "55",                 # reservationId
                 "2",                  # connectorId
@@ -408,9 +401,8 @@ class TestInteractiveReservationHandle:
                 "GROUP-X",            # parentIdTag
                 "2025-01-15T13:00:00+00:00",  # expiryDate
             ]
-            result = await ocpp_j_device.interactive_reservation_handle("4")
+            await ocpp_j_device.interactive_reservation_make()
 
-        assert result is True
         passed_options = ocpp_j_device.flow_reserve.await_args.args[0]
         assert passed_options["reservationId"] == 55
         assert passed_options["connectorId"] == 2
@@ -422,9 +414,10 @@ class TestInteractiveReservationHandle:
     @pytest.mark.asyncio
     async def test_make_reservation_blank_parent_and_expiry_use_defaults(self, ocpp_j_device):
         ocpp_j_device.flow_reserve = AsyncMock(return_value=True)
-        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input, \
+             patch("charge_device_simulator.device.utility._is_tty", return_value=False):
             mock_input.side_effect = ["10", "1", "X", "", ""]
-            await ocpp_j_device.interactive_reservation_handle("4")
+            await ocpp_j_device.interactive_reservation_make()
 
         passed_options = ocpp_j_device.flow_reserve.await_args.args[0]
         assert passed_options["parentIdTag"] is None
@@ -436,9 +429,10 @@ class TestInteractiveReservationHandle:
         _seed_reservation(ocpp_j_device, reservation_id=42)
         ocpp_j_device.flow_reservation_cancel = AsyncMock(return_value=True)
 
-        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input, \
+             patch("charge_device_simulator.device.utility._is_tty", return_value=False):
             mock_input.side_effect = [""]
-            await ocpp_j_device.interactive_reservation_handle("5")
+            await ocpp_j_device.interactive_reservation_cancel()
 
         ocpp_j_device.flow_reservation_cancel.assert_awaited_once_with(42)
 
@@ -447,9 +441,10 @@ class TestInteractiveReservationHandle:
         _seed_reservation(ocpp_j_device, reservation_id=42)
         ocpp_j_device.flow_reservation_cancel = AsyncMock(return_value=True)
 
-        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input, \
+             patch("charge_device_simulator.device.utility._is_tty", return_value=False):
             mock_input.side_effect = ["999"]
-            await ocpp_j_device.interactive_reservation_handle("5")
+            await ocpp_j_device.interactive_reservation_cancel()
 
         ocpp_j_device.flow_reservation_cancel.assert_awaited_once_with(999)
 

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -1,6 +1,8 @@
 import datetime
 import math
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from charge_device_simulator.device.ocpp_j.abstract_device_ocpp_j import AbstractDeviceOcppJ
 
@@ -205,3 +207,320 @@ class TestOptionsPersistence:
 
         # All results should be increasing
         assert result1 < result2 < result3 < result4
+
+
+def _seed_reservation(device, *, reservation_id=42, connector_id=1,
+                      id_tag="RFID-A", parent_id_tag=None,
+                      expiry_date="2025-01-15T13:00:00+00:00"):
+    device.reservation_set(
+        reservation_id=reservation_id,
+        connector_id=connector_id,
+        id_tag=id_tag,
+        parent_id_tag=parent_id_tag,
+        expiry_date=expiry_date,
+    )
+
+
+class TestFlowReserve:
+    @pytest.mark.asyncio
+    async def test_accepted_stores_state_and_sends_reserved_status(self, ocpp_j_device):
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+
+        result = await ocpp_j_device.flow_reserve({
+            "reservationId": 7,
+            "connectorId": 2,
+            "idTag": "RFID-A",
+            "parentIdTag": "GROUP-X",
+            "expiryDate": "2025-01-15T13:00:00+00:00",
+        })
+
+        assert result is True
+        assert ocpp_j_device.reservation_id == 7
+        assert ocpp_j_device.reservation_connector_id == 2
+        assert ocpp_j_device.reservation_id_tag == "RFID-A"
+        assert ocpp_j_device.reservation_parent_id_tag == "GROUP-X"
+        ocpp_j_device.action_status_update.assert_awaited_once()
+        assert ocpp_j_device.action_status_update.await_args.args[0] == "Reserved"
+
+    @pytest.mark.asyncio
+    async def test_rejected_when_charging(self, ocpp_j_device):
+        ocpp_j_device.charge_in_progress = True
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+
+        result = await ocpp_j_device.flow_reserve({
+            "reservationId": 7, "connectorId": 1, "idTag": "RFID-A"
+        })
+
+        assert result is False
+        assert not ocpp_j_device.reservation_is_active()
+        ocpp_j_device.action_status_update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejected_when_connector_already_reserved(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=1, connector_id=1)
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+
+        result = await ocpp_j_device.flow_reserve({
+            "reservationId": 99, "connectorId": 1, "idTag": "OTHER"
+        })
+
+        assert result is False
+        # Existing reservation untouched
+        assert ocpp_j_device.reservation_id == 1
+        ocpp_j_device.action_status_update.assert_not_awaited()
+
+
+class TestFlowReservationCancel:
+    @pytest.mark.asyncio
+    async def test_accepted_clears_state_and_sends_available(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=42, connector_id=3)
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+
+        result = await ocpp_j_device.flow_reservation_cancel(42)
+
+        assert result is True
+        assert not ocpp_j_device.reservation_is_active()
+        ocpp_j_device.action_status_update.assert_awaited_once()
+        args = ocpp_j_device.action_status_update.await_args.args
+        assert args[0] == "Available"
+        assert args[1]["connectorId"] == 3
+
+    @pytest.mark.asyncio
+    async def test_rejected_for_unknown_id_keeps_state(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=42, connector_id=3)
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+
+        result = await ocpp_j_device.flow_reservation_cancel(999)
+
+        assert result is False
+        assert ocpp_j_device.reservation_id == 42
+        ocpp_j_device.action_status_update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_explicit_options_are_passed_through_to_status_update(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=42, connector_id=3)
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+
+        result = await ocpp_j_device.flow_reservation_cancel(
+            42, {"evseId": 7, "connectorId": 9})
+
+        assert result is True
+        passed = ocpp_j_device.action_status_update.await_args.args[1]
+        # Caller-provided connectorId must be preserved (not overwritten by setdefault)
+        assert passed["connectorId"] == 9
+        assert passed["evseId"] == 7
+
+
+class TestPreChargeReservationGate:
+    def test_no_reservation_passes(self, ocpp_j_device):
+        assert ocpp_j_device._pre_charge_reservation_gate({"connectorId": 1, "idTag": "X"}) is True
+
+    def test_reservation_on_other_connector_does_not_apply(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, connector_id=2, id_tag="RES-TAG")
+        options = {"connectorId": 1, "idTag": "OTHER"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is True
+        assert "reservationId" not in options
+
+    def test_id_tag_match_injects_reservation_id(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=11, connector_id=1, id_tag="RES-TAG")
+        options = {"connectorId": 1, "idTag": "RES-TAG"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is True
+        assert options["reservationId"] == 11
+
+    def test_parent_match_injects_reservation_id(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=12, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        ocpp_j_device._last_authorize_info = {"id_tag": "FRIEND", "parent_id_tag": "GROUP-X"}
+        options = {"connectorId": 1, "idTag": "FRIEND"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is True
+        assert options["reservationId"] == 12
+
+    def test_no_match_blocks_charge(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=13, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        ocpp_j_device._last_authorize_info = {"id_tag": "INTRUDER", "parent_id_tag": "GROUP-Y"}
+        options = {"connectorId": 1, "idTag": "INTRUDER"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is False
+        assert "reservationId" not in options
+
+    def test_reservation_with_no_authorize_info_falls_through_to_id_tag_only(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=14, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        ocpp_j_device._last_authorize_info = None
+        options = {"connectorId": 1, "idTag": "INTRUDER"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is False
+
+
+class TestConsumeReservationIfUsed:
+    def test_clears_when_reservation_id_in_options_matches(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=99)
+        options = {"reservationId": 99}
+
+        ocpp_j_device._consume_reservation_if_used(options)
+
+        assert not ocpp_j_device.reservation_is_active()
+
+    def test_keeps_state_when_no_reservation_id_in_options(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=99)
+        ocpp_j_device._consume_reservation_if_used({})
+        assert ocpp_j_device.reservation_id == 99
+
+    def test_does_not_clear_when_reservation_ids_mismatch(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=99)
+        ocpp_j_device._consume_reservation_if_used({"reservationId": 100})
+        assert ocpp_j_device.reservation_id == 99
+
+
+class TestInteractiveReservationHandle:
+    @pytest.mark.asyncio
+    async def test_show_state_returns_true_without_side_effects(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=42)
+        ocpp_j_device.flow_reserve = AsyncMock()
+        ocpp_j_device.flow_reservation_cancel = AsyncMock()
+
+        result = await ocpp_j_device.interactive_reservation_handle("3")
+
+        assert result is True
+        # No reservation flows are kicked off by "show state"
+        ocpp_j_device.flow_reserve.assert_not_awaited()
+        ocpp_j_device.flow_reservation_cancel.assert_not_awaited()
+        # State unchanged
+        assert ocpp_j_device.reservation_id == 42
+
+    @pytest.mark.asyncio
+    async def test_unknown_input_returns_false(self, ocpp_j_device):
+        assert await ocpp_j_device.interactive_reservation_handle("99") is False
+        assert await ocpp_j_device.interactive_reservation_handle("0") is False
+
+    @pytest.mark.asyncio
+    async def test_make_reservation_collects_inputs_and_invokes_flow(self, ocpp_j_device):
+        ocpp_j_device.flow_reserve = AsyncMock(return_value=True)
+        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = [
+                "55",                 # reservationId
+                "2",                  # connectorId
+                "RFID-A",             # idTag
+                "GROUP-X",            # parentIdTag
+                "2025-01-15T13:00:00+00:00",  # expiryDate
+            ]
+            result = await ocpp_j_device.interactive_reservation_handle("4")
+
+        assert result is True
+        passed_options = ocpp_j_device.flow_reserve.await_args.args[0]
+        assert passed_options["reservationId"] == 55
+        assert passed_options["connectorId"] == 2
+        assert passed_options["evseId"] == 2
+        assert passed_options["idTag"] == "RFID-A"
+        assert passed_options["parentIdTag"] == "GROUP-X"
+        assert passed_options["expiryDate"] == "2025-01-15T13:00:00+00:00"
+
+    @pytest.mark.asyncio
+    async def test_make_reservation_blank_parent_and_expiry_use_defaults(self, ocpp_j_device):
+        ocpp_j_device.flow_reserve = AsyncMock(return_value=True)
+        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["10", "1", "X", "", ""]
+            await ocpp_j_device.interactive_reservation_handle("4")
+
+        passed_options = ocpp_j_device.flow_reserve.await_args.args[0]
+        assert passed_options["parentIdTag"] is None
+        # Blank expiry → ISO timestamp (defaulted now+1h)
+        assert "T" in passed_options["expiryDate"]
+
+    @pytest.mark.asyncio
+    async def test_cancel_reservation_blank_uses_stored_id(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=42)
+        ocpp_j_device.flow_reservation_cancel = AsyncMock(return_value=True)
+
+        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = [""]
+            await ocpp_j_device.interactive_reservation_handle("5")
+
+        ocpp_j_device.flow_reservation_cancel.assert_awaited_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_cancel_reservation_uses_explicit_id(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=42)
+        ocpp_j_device.flow_reservation_cancel = AsyncMock(return_value=True)
+
+        with patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["999"]
+            await ocpp_j_device.interactive_reservation_handle("5")
+
+        ocpp_j_device.flow_reservation_cancel.assert_awaited_once_with(999)
+
+
+class TestInboundReserveNowCancelReservation:
+    """Tests for the by_middleware_req routing of ReserveNow / CancelReservation.
+
+    The inbound handler schedules flow_reserve / flow_reservation_cancel via
+    asyncio.create_task with a delay. We replace those methods with plain
+    Mocks (not AsyncMock) and stub run_with_delay so no background coroutine
+    is created — keeping these tests focused on the response payload only."""
+
+    @pytest.mark.asyncio
+    async def test_reserve_now_accepted_when_idle(self, ocpp_j_device):
+        ocpp_j_device.by_middleware_req_response_ready = AsyncMock()
+        ocpp_j_device.flow_reserve = MagicMock()
+
+        with patch("charge_device_simulator.device.utility.run_with_delay", return_value=None):
+            await ocpp_j_device.by_middleware_req("req1", "reservenow", {
+                "reservationId": 1, "connectorId": 1, "idTag": "X",
+                "expiryDate": "2025-01-15T13:00:00+00:00"
+            })
+
+        resp = ocpp_j_device.by_middleware_req_response_ready.await_args.args[1]
+        assert resp == {"status": "Accepted"}
+        ocpp_j_device.flow_reserve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reserve_now_rejected_when_connector_id_missing(self, ocpp_j_device):
+        ocpp_j_device.by_middleware_req_response_ready = AsyncMock()
+
+        await ocpp_j_device.by_middleware_req("req1", "reservenow", {
+            "reservationId": 1, "idTag": "X"  # connectorId missing — required in 1.6
+        })
+
+        resp = ocpp_j_device.by_middleware_req_response_ready.await_args.args[1]
+        assert resp == {"status": "Rejected"}
+
+    @pytest.mark.asyncio
+    async def test_reserve_now_occupied_when_already_reserved(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, connector_id=1)
+        ocpp_j_device.by_middleware_req_response_ready = AsyncMock()
+
+        await ocpp_j_device.by_middleware_req("req1", "reservenow", {
+            "reservationId": 2, "connectorId": 1, "idTag": "Y"
+        })
+
+        resp = ocpp_j_device.by_middleware_req_response_ready.await_args.args[1]
+        assert resp == {"status": "Occupied"}
+
+    @pytest.mark.asyncio
+    async def test_cancel_reservation_accepted_when_id_matches(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=42)
+        ocpp_j_device.by_middleware_req_response_ready = AsyncMock()
+        ocpp_j_device.flow_reservation_cancel = MagicMock()
+
+        with patch("charge_device_simulator.device.utility.run_with_delay", return_value=None):
+            await ocpp_j_device.by_middleware_req("req1", "cancelreservation",
+                                                  {"reservationId": 42})
+
+        resp = ocpp_j_device.by_middleware_req_response_ready.await_args.args[1]
+        assert resp == {"status": "Accepted"}
+        ocpp_j_device.flow_reservation_cancel.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_cancel_reservation_rejected_for_unknown_id(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=42)
+        ocpp_j_device.by_middleware_req_response_ready = AsyncMock()
+
+        await ocpp_j_device.by_middleware_req("req1", "cancelreservation",
+                                              {"reservationId": 999})
+
+        resp = ocpp_j_device.by_middleware_req_response_ready.await_args.args[1]
+        assert resp == {"status": "Rejected"}

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -355,6 +355,18 @@ class TestPreChargeReservationGate:
 
         assert ocpp_j_device._pre_charge_reservation_gate(options) is False
 
+    def test_missing_connector_id_still_applies_gate_to_default_connector(self, ocpp_j_device):
+        # Reservation is on connector 1; user's options omit connectorId.
+        # Without the get-with-default, the gate would compare None vs 1 and
+        # silently let the charge through.
+        _seed_reservation(ocpp_j_device, reservation_id=15, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        ocpp_j_device._last_authorize_info = {"id_tag": "INTRUDER", "parent_id_tag": "GROUP-Y"}
+        options = {"idTag": "INTRUDER"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is False
+        assert "reservationId" not in options
+
 
 class TestConsumeReservationIfUsed:
     def test_clears_when_reservation_id_in_options_matches(self, ocpp_j_device):

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -376,6 +376,44 @@ class TestConsumeReservationIfUsed:
         assert ocpp_j_device.reservation_id == 99
 
 
+class TestResetChargeCycleOptions:
+    """A second `flow_charge` invocation in an interactive session must not
+    replay the previous cycle's start/stop time or computed meterStop. The
+    same reset must NOT happen in non-interactive (frequent-flow) runs to
+    preserve historical behavior."""
+
+    def _stale_options(self):
+        return {
+            "idTag": "ABC",
+            "connectorId": 1,
+            "chargeStartTime": "2025-01-15T12:00:00+00:00",
+            "chargeStopTime": "2025-01-15T12:30:00+00:00",
+            "meterStop": 31000,
+            "meterStart": 1000,
+        }
+
+    def test_drops_stale_charge_cycle_keys_when_interactive(self, ocpp_j_device):
+        ocpp_j_device.interactive_mode = True
+        options = self._stale_options()
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        assert "chargeStartTime" not in options
+        assert "chargeStopTime" not in options
+        assert "meterStop" not in options
+        # Caller-supplied config (idTag, connectorId, meterStart) is untouched
+        assert options == {"idTag": "ABC", "connectorId": 1, "meterStart": 1000}
+
+    def test_keeps_options_when_not_interactive(self, ocpp_j_device):
+        # Default (interactive_mode=False) — frequent-flow / non-interactive run
+        options = self._stale_options()
+        snapshot = dict(options)
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        assert options == snapshot
+
+
 class TestInteractiveReservationHandlers:
     @pytest.mark.asyncio
     async def test_show_state_does_not_invoke_flows(self, ocpp_j_device):

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -1,0 +1,142 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _stub_authorize_response(id_tag: str, parent_id_tag: str = None):
+    info = {"status": "Accepted"}
+    if parent_id_tag is not None:
+        info["parentIdTag"] = parent_id_tag
+    return [3, "req-1", {"idTagInfo": info}]
+
+
+def _stub_start_transaction_response(transaction_id: int = 555):
+    return [3, "req-1", {"idTagInfo": {"status": "Accepted"}, "transactionId": transaction_id}]
+
+
+def _seed_reservation(device, *, reservation_id=42, connector_id=1,
+                      id_tag="RFID-A", parent_id_tag=None):
+    device.reservation_set(
+        reservation_id=reservation_id,
+        connector_id=connector_id,
+        id_tag=id_tag,
+        parent_id_tag=parent_id_tag,
+        expiry_date="2025-01-15T13:00:00+00:00",
+    )
+
+
+class TestJ16AuthorizeStashesParent:
+    @pytest.mark.asyncio
+    async def test_parent_id_tag_captured_from_response(self, device_ocpp_j16):
+        device_ocpp_j16.by_device_req_send = AsyncMock(
+            return_value=_stub_authorize_response("RFID-A", parent_id_tag="GROUP-X"))
+
+        ok = await device_ocpp_j16.action_authorize({"idTag": "RFID-A"})
+
+        assert ok is True
+        assert device_ocpp_j16._last_authorize_info["parent_id_tag"] == "GROUP-X"
+
+
+class TestJ16StartTransactionWithReservation:
+    @pytest.mark.asyncio
+    async def test_id_tag_match_includes_reservation_id_in_start(self, device_ocpp_j16):
+        _seed_reservation(device_ocpp_j16, reservation_id=42, connector_id=1, id_tag="RFID-A")
+        device_ocpp_j16._last_authorize_info = {"id_tag": "RFID-A", "parent_id_tag": None}
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return _stub_start_transaction_response()
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        # Simulate the gate decision (would normally happen in flow_charge)
+        options = {"connectorId": 1, "idTag": "RFID-A"}
+        assert device_ocpp_j16._pre_charge_reservation_gate(options) is True
+        assert await device_ocpp_j16.action_charge_start(options) is True
+        device_ocpp_j16._consume_reservation_if_used(options)
+
+        assert captured["StartTransaction"]["reservationId"] == 42
+        assert not device_ocpp_j16.reservation_is_active()
+
+    @pytest.mark.asyncio
+    async def test_parent_match_includes_reservation_id_in_start(self, device_ocpp_j16):
+        _seed_reservation(device_ocpp_j16, reservation_id=43, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        device_ocpp_j16._last_authorize_info = {"id_tag": "FRIEND", "parent_id_tag": "GROUP-X"}
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return _stub_start_transaction_response()
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        options = {"connectorId": 1, "idTag": "FRIEND"}
+        assert device_ocpp_j16._pre_charge_reservation_gate(options) is True
+        assert await device_ocpp_j16.action_charge_start(options) is True
+
+        assert captured["StartTransaction"]["reservationId"] == 43
+
+    @pytest.mark.asyncio
+    async def test_no_reservation_id_when_no_active_reservation(self, device_ocpp_j16):
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return _stub_start_transaction_response()
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        await device_ocpp_j16.action_charge_start({"connectorId": 1, "idTag": "X"})
+
+        assert "reservationId" not in captured["StartTransaction"]
+
+
+class TestJ16FlowChargeReservationGate:
+    @pytest.mark.asyncio
+    async def test_flow_charge_aborts_when_authorize_does_not_match_reservation(
+            self, device_ocpp_j16):
+        _seed_reservation(device_ocpp_j16, reservation_id=42, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append(action)
+            if action == "Authorize":
+                # Returned tag has neither idTag nor parentIdTag matching the reservation
+                return [3, "req-1", {
+                    "idTagInfo": {"status": "Accepted", "parentIdTag": "GROUP-Y"}}]
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}, "transactionId": 1}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        ok = await device_ocpp_j16.flow_charge(True, {"connectorId": 1, "idTag": "INTRUDER"})
+
+        assert ok is False
+        # Authorize was sent, but no StartTransaction or status updates followed
+        assert "Authorize" in sent
+        assert "StartTransaction" not in sent
+        assert "StatusNotification" not in sent
+        # Reservation preserved
+        assert device_ocpp_j16.reservation_is_active()
+
+
+class TestJ16FlowReserveStatusPayload:
+    @pytest.mark.asyncio
+    async def test_reserved_status_uses_1_6_status_field(self, device_ocpp_j16):
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return [3, "req-1", {}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        ok = await device_ocpp_j16.flow_reserve({
+            "reservationId": 5, "connectorId": 1, "idTag": "X"
+        })
+
+        assert ok is True
+        assert captured["StatusNotification"]["status"] == "Reserved"
+        assert captured["StatusNotification"]["connectorId"] == 1

--- a/tests/test_device_ocpp_j201.py
+++ b/tests/test_device_ocpp_j201.py
@@ -1,0 +1,158 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _stub_authorize_response(id_tag: str, group_id_tag: str = None):
+    info = {"status": "Accepted"}
+    if group_id_tag is not None:
+        info["groupIdToken"] = {"idToken": group_id_tag, "type": "Central"}
+    return [3, "req-1", {"idTokenInfo": info}]
+
+
+def _stub_transaction_event_response():
+    return [3, "req-1", {"idTokenInfo": {"status": "Accepted"}}]
+
+
+def _seed_reservation(device, *, reservation_id=42, connector_id=1,
+                      id_tag="RFID-A", parent_id_tag=None):
+    device.reservation_set(
+        reservation_id=reservation_id,
+        connector_id=connector_id,
+        id_tag=id_tag,
+        parent_id_tag=parent_id_tag,
+        expiry_date="2025-01-15T13:00:00+00:00",
+    )
+
+
+class TestJ201AuthorizeStashesGroup:
+    @pytest.mark.asyncio
+    async def test_group_id_token_captured_from_response(self, device_ocpp_j201):
+        device_ocpp_j201.by_device_req_send = AsyncMock(
+            return_value=_stub_authorize_response("RFID-A", group_id_tag="GROUP-X"))
+
+        ok = await device_ocpp_j201.action_authorize({"idTag": "RFID-A"})
+
+        assert ok is True
+        assert device_ocpp_j201._last_authorize_info["parent_id_tag"] == "GROUP-X"
+
+    @pytest.mark.asyncio
+    async def test_no_group_id_token_yields_none_parent(self, device_ocpp_j201):
+        device_ocpp_j201.by_device_req_send = AsyncMock(
+            return_value=_stub_authorize_response("RFID-A"))
+
+        await device_ocpp_j201.action_authorize({"idTag": "RFID-A"})
+
+        assert device_ocpp_j201._last_authorize_info["parent_id_tag"] is None
+
+
+class TestJ201TransactionEventWithReservation:
+    @pytest.mark.asyncio
+    async def test_id_tag_match_includes_reservation_id_at_top_level(self, device_ocpp_j201):
+        _seed_reservation(device_ocpp_j201, reservation_id=77, connector_id=1, id_tag="RFID-A")
+        device_ocpp_j201._last_authorize_info = {"id_tag": "RFID-A", "parent_id_tag": None}
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return _stub_transaction_event_response()
+
+        device_ocpp_j201.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        options = {"connectorId": 1, "idTag": "RFID-A"}
+        assert device_ocpp_j201._pre_charge_reservation_gate(options) is True
+        assert await device_ocpp_j201.action_charge_start(options) is True
+        device_ocpp_j201._consume_reservation_if_used(options)
+
+        assert captured["TransactionEvent"]["reservationId"] == 77
+        # reservationId is at the top level of TransactionEvent in 2.0.1, not inside transactionInfo
+        assert "reservationId" not in captured["TransactionEvent"]["transactionInfo"]
+        assert not device_ocpp_j201.reservation_is_active()
+
+    @pytest.mark.asyncio
+    async def test_group_match_includes_reservation_id(self, device_ocpp_j201):
+        _seed_reservation(device_ocpp_j201, reservation_id=78, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        device_ocpp_j201._last_authorize_info = {"id_tag": "FRIEND", "parent_id_tag": "GROUP-X"}
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return _stub_transaction_event_response()
+
+        device_ocpp_j201.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        options = {"connectorId": 1, "idTag": "FRIEND"}
+        assert device_ocpp_j201._pre_charge_reservation_gate(options) is True
+        assert await device_ocpp_j201.action_charge_start(options) is True
+
+        assert captured["TransactionEvent"]["reservationId"] == 78
+
+class TestJ201ReserveNowOptionsFromPayload:
+    def test_maps_2_0_1_payload_shape(self, device_ocpp_j201):
+        options = device_ocpp_j201._reserve_now_options_from_payload({
+            "id": 42,
+            "expiryDateTime": "2025-01-15T13:00:00+00:00",
+            "evseId": 2,
+            "idToken": {"idToken": "RFID-A", "type": "ISO14443"},
+            "groupIdToken": {"idToken": "GROUP-X", "type": "Central"},
+        })
+
+        assert options == {
+            "reservationId": 42,
+            "connectorId": 2,
+            "evseId": 2,
+            "idTag": "RFID-A",
+            "parentIdTag": "GROUP-X",
+            "expiryDate": "2025-01-15T13:00:00+00:00",
+        }
+
+
+class TestJ201FlowChargeReservationGate:
+    @pytest.mark.asyncio
+    async def test_flow_charge_aborts_when_authorize_does_not_match_reservation(
+            self, device_ocpp_j201):
+        _seed_reservation(device_ocpp_j201, reservation_id=42, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append(action)
+            if action == "Authorize":
+                return [3, "req-1", {"idTokenInfo": {
+                    "status": "Accepted",
+                    "groupIdToken": {"idToken": "GROUP-Y", "type": "Central"},
+                }}]
+            return [3, "req-1", {"idTokenInfo": {"status": "Accepted"}}]
+
+        device_ocpp_j201.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        ok = await device_ocpp_j201.flow_charge(True, {"connectorId": 1, "idTag": "INTRUDER"})
+
+        assert ok is False
+        assert "Authorize" in sent
+        # j201 sends StatusNotification("Occupied") AFTER the gate, so neither it nor
+        # the TransactionEvent should be sent on a gate rejection
+        assert "TransactionEvent" not in sent
+        assert "StatusNotification" not in sent
+        assert device_ocpp_j201.reservation_is_active()
+
+
+class TestJ201FlowReserveStatusPayload:
+    @pytest.mark.asyncio
+    async def test_reserved_status_uses_2_0_1_connector_status_field(self, device_ocpp_j201):
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return [3, "req-1", {}]
+
+        device_ocpp_j201.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        ok = await device_ocpp_j201.flow_reserve({
+            "reservationId": 5, "connectorId": 1, "evseId": 1, "idTag": "X"
+        })
+
+        assert ok is True
+        assert captured["StatusNotification"]["connectorStatus"] == "Reserved"
+        assert captured["StatusNotification"]["evseId"] == 1

--- a/tests/test_device_ocpp_s.py
+++ b/tests/test_device_ocpp_s.py
@@ -1,6 +1,8 @@
 import datetime
 import math
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from charge_device_simulator.device.ocpp_s.device_ocpp_s import DeviceOcppS
 
@@ -121,3 +123,140 @@ class TestDeviceOcppSOptionsPersistence:
         # Verify meterStop was added
         assert "meterStop" in options
         assert "chargeStopTime" in options
+
+
+def _seed_reservation(device, *, reservation_id=42, connector_id=1,
+                      id_tag="RFID-A", parent_id_tag=None):
+    device.reservation_set(
+        reservation_id=reservation_id,
+        connector_id=connector_id,
+        id_tag=id_tag,
+        parent_id_tag=parent_id_tag,
+        expiry_date="2025-01-15T13:00:00+00:00",
+    )
+
+
+class TestOcppSAuthorizeStashesParent:
+    @pytest.mark.asyncio
+    async def test_parent_id_tag_extracted_from_nested_id_tag_info(self, device_ocpp_s):
+        device_ocpp_s.by_device_req_send = AsyncMock(return_value={
+            "status": "Accepted",
+            "idTagInfo": {"status": "Accepted", "parentIdTag": "GROUP-X"},
+        })
+
+        ok = await device_ocpp_s.action_authorize({"idTag": "RFID-A"})
+
+        assert ok is True
+        assert device_ocpp_s._last_authorize_info["parent_id_tag"] == "GROUP-X"
+
+    @pytest.mark.asyncio
+    async def test_parent_id_tag_falls_back_to_top_level(self, device_ocpp_s):
+        device_ocpp_s.by_device_req_send = AsyncMock(return_value={
+            "status": "Accepted",
+            "parentIdTag": "GROUP-Y",
+        })
+
+        await device_ocpp_s.action_authorize({"idTag": "RFID-B"})
+
+        assert device_ocpp_s._last_authorize_info["parent_id_tag"] == "GROUP-Y"
+
+
+class TestOcppSStartTransactionWithReservation:
+    @pytest.mark.asyncio
+    async def test_id_tag_match_includes_reservation_id_in_start(self, device_ocpp_s):
+        _seed_reservation(device_ocpp_s, reservation_id=42, connector_id=1, id_tag="RFID-A")
+        device_ocpp_s._last_authorize_info = {"id_tag": "RFID-A", "parent_id_tag": None}
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return {"idTagInfo": {"status": "Accepted"}, "transactionId": 555}
+
+        device_ocpp_s.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        options = {"connectorId": 1, "idTag": "RFID-A"}
+        assert device_ocpp_s._pre_charge_reservation_gate(options) is True
+        assert await device_ocpp_s.action_charge_start(options) is True
+        device_ocpp_s._consume_reservation_if_used(options)
+
+        assert captured["StartTransaction"]["reservationId"] == 42
+        assert not device_ocpp_s.reservation_is_active()
+
+    @pytest.mark.asyncio
+    async def test_parent_match_includes_reservation_id_in_start(self, device_ocpp_s):
+        _seed_reservation(device_ocpp_s, reservation_id=43, connector_id=1,
+                          id_tag="OWNER", parent_id_tag="GROUP-X")
+        device_ocpp_s._last_authorize_info = {"id_tag": "FRIEND", "parent_id_tag": "GROUP-X"}
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return {"idTagInfo": {"status": "Accepted"}, "transactionId": 556}
+
+        device_ocpp_s.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        options = {"connectorId": 1, "idTag": "FRIEND"}
+        assert device_ocpp_s._pre_charge_reservation_gate(options) is True
+        assert await device_ocpp_s.action_charge_start(options) is True
+
+        assert captured["StartTransaction"]["reservationId"] == 43
+
+
+class TestOcppSInboundReserveAndCancel:
+    """Replaces flow_reserve / flow_reservation_cancel with plain Mocks and stubs
+    run_with_delay so the background task is not actually scheduled — keeps these
+    focused on the inbound response decision."""
+
+    @pytest.mark.asyncio
+    async def test_reserve_now_accepted_and_schedules_flow(self, device_ocpp_s):
+        device_ocpp_s.flow_reserve = MagicMock()
+
+        with patch("charge_device_simulator.device.utility.run_with_delay", return_value=None):
+            resp = await device_ocpp_s.by_middleware_req("req1", "reservenow", {
+                "reservationId": 7, "connectorId": 1, "idTag": "X",
+                "expiryDate": "2025-01-15T13:00:00+00:00"
+            })
+
+        assert resp == {"status": "Accepted"}
+        device_ocpp_s.flow_reserve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_reservation_accepted_when_id_matches(self, device_ocpp_s):
+        _seed_reservation(device_ocpp_s, reservation_id=42)
+        device_ocpp_s.flow_reservation_cancel = MagicMock()
+
+        with patch("charge_device_simulator.device.utility.run_with_delay", return_value=None):
+            resp = await device_ocpp_s.by_middleware_req("req1", "cancelreservation",
+                                                         {"reservationId": 42})
+
+        assert resp == {"status": "Accepted"}
+        device_ocpp_s.flow_reservation_cancel.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_cancel_reservation_rejected_for_unknown_id(self, device_ocpp_s):
+        _seed_reservation(device_ocpp_s, reservation_id=42)
+
+        resp = await device_ocpp_s.by_middleware_req("req1", "cancelreservation",
+                                                     {"reservationId": 999})
+
+        assert resp == {"status": "Rejected"}
+
+
+class TestOcppSFlowReserveStatusPayload:
+    @pytest.mark.asyncio
+    async def test_reserved_status_uses_status_field(self, device_ocpp_s):
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return {}
+
+        device_ocpp_s.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        ok = await device_ocpp_s.flow_reserve({
+            "reservationId": 5, "connectorId": 1, "idTag": "X"
+        })
+
+        assert ok is True
+        assert captured["StatusNotification"]["status"] == "Reserved"
+        assert captured["StatusNotification"]["connectorId"] == 1

--- a/tests/test_ocpp_enums.py
+++ b/tests/test_ocpp_enums.py
@@ -1,0 +1,34 @@
+from charge_device_simulator.device import ocpp_enums
+
+
+def _all_tuple_constants():
+    return [
+        ("OCPP_16_CONNECTOR_STATUSES", ocpp_enums.OCPP_16_CONNECTOR_STATUSES),
+        ("OCPP_16_ERROR_CODES", ocpp_enums.OCPP_16_ERROR_CODES),
+        ("OCPP_16_AVAILABILITY_TYPES", ocpp_enums.OCPP_16_AVAILABILITY_TYPES),
+        ("OCPP_16_RESET_TYPES", ocpp_enums.OCPP_16_RESET_TYPES),
+        ("OCPP_16_CHARGING_PROFILE_PURPOSES", ocpp_enums.OCPP_16_CHARGING_PROFILE_PURPOSES),
+        ("OCPP_201_CONNECTOR_STATUSES", ocpp_enums.OCPP_201_CONNECTOR_STATUSES),
+        ("OCPP_201_ID_TOKEN_TYPES", ocpp_enums.OCPP_201_ID_TOKEN_TYPES),
+        ("OCPP_201_RESET_TYPES", ocpp_enums.OCPP_201_RESET_TYPES),
+        ("OCPP_S_AUTHORIZATION_STATUSES", ocpp_enums.OCPP_S_AUTHORIZATION_STATUSES),
+    ]
+
+
+class TestEnumConstants:
+    def test_each_constant_is_non_empty_tuple_with_no_duplicates(self):
+        for name, values in _all_tuple_constants():
+            assert isinstance(values, tuple), f"{name} must be a tuple"
+            assert len(values) > 0, f"{name} must be non-empty"
+            assert len(set(values)) == len(values), f"{name} contains duplicates"
+            assert all(isinstance(v, str) for v in values), f"{name} must contain strings"
+
+    def test_canonical_spec_values_present(self):
+        # Spot-checks for values the wiring relies on
+        assert "NoError" in ocpp_enums.OCPP_16_ERROR_CODES
+        assert "SuspendedEVSE" in ocpp_enums.OCPP_16_CONNECTOR_STATUSES
+        assert "SuspendedEV" in ocpp_enums.OCPP_16_CONNECTOR_STATUSES
+        assert "Reserved" in ocpp_enums.OCPP_16_CONNECTOR_STATUSES
+        assert "Occupied" in ocpp_enums.OCPP_201_CONNECTOR_STATUSES
+        assert "ISO14443" in ocpp_enums.OCPP_201_ID_TOKEN_TYPES
+        assert "ConcurrentTx" in ocpp_enums.OCPP_S_AUTHORIZATION_STATUSES

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -143,6 +143,36 @@ class TestSimulatorRfidSwipe:
         assert passed_options is not simulator.flow_charge_options
 
 
+class TestErrorExitInteractiveBehavior:
+    """When the operator runs in interactive mode, a CSMS-rejected response
+    should drop them back to the menu rather than sys.exit'ing the process."""
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_start_disables_error_exit_when_interactive(
+            self, simulator, mock_device):
+        mock_device.error_exit = True
+        simulator.is_interactive = True
+        simulator.frequent_flow_enabled = False
+        # Stub the interactive loop so lifecycle_start returns immediately
+        with patch.object(simulator, "loop_interactive", new_callable=AsyncMock):
+            await simulator.lifecycle_start()
+
+        assert mock_device.error_exit is False
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_start_keeps_error_exit_when_not_interactive(
+            self, simulator, mock_device):
+        mock_device.error_exit = True
+        simulator.is_interactive = False
+        simulator.frequent_flow_enabled = False
+
+        await simulator.lifecycle_start()
+
+        # error_exit must remain True so frequent-flow / non-interactive runs
+        # still crash on rejected responses (the existing fail-fast behavior).
+        assert mock_device.error_exit is True
+
+
 class TestSimulatorErrorHandling:
     """Tests for simulator error handling."""
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -122,6 +122,27 @@ class TestSimulatorOptionsPersistence:
         assert id(simulator.flow_charge_options) == original_id
 
 
+class TestSimulatorRfidSwipe:
+    @pytest.mark.asyncio
+    async def test_rfid_swipe_passes_entered_id_tag_without_mutating_config(self, simulator, mock_device):
+        original_options = simulator.flow_charge_options
+        original_id = id(original_options)
+        original_id_tag = original_options.get("idTag")
+
+        with patch('aioconsole.ainput', new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["4", "RFID-SWIPED-TAG", "0"]
+            await simulator.loop_interactive()
+
+        mock_device.flow_charge.assert_called_once()
+        passed_options = mock_device.flow_charge.call_args.args[1]
+        assert passed_options["idTag"] == "RFID-SWIPED-TAG"
+        # Configured options must not be mutated
+        assert simulator.flow_charge_options.get("idTag") == original_id_tag
+        assert id(simulator.flow_charge_options) == original_id
+        # The swipe options were a copy, not the same dict
+        assert passed_options is not simulator.flow_charge_options
+
+
 class TestSimulatorErrorHandling:
     """Tests for simulator error handling."""
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -183,6 +183,28 @@ class TestErrorExitInteractiveBehavior:
         # still crash on rejected responses (the existing fail-fast behavior).
         assert mock_device.error_exit is True
 
+    @pytest.mark.asyncio
+    async def test_lifecycle_start_flips_interactive_mode(
+            self, simulator, mock_device):
+        mock_device.interactive_mode = False
+        simulator.is_interactive = True
+        simulator.frequent_flow_enabled = False
+        with patch.object(simulator, "loop_interactive", new_callable=AsyncMock):
+            await simulator.lifecycle_start()
+
+        assert mock_device.interactive_mode is True
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_start_leaves_interactive_mode_when_not_interactive(
+            self, simulator, mock_device):
+        mock_device.interactive_mode = False
+        simulator.is_interactive = False
+        simulator.frequent_flow_enabled = False
+
+        await simulator.lifecycle_start()
+
+        assert mock_device.interactive_mode is False
+
 
 class TestSimulatorErrorHandling:
     """Tests for simulator error handling."""

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -68,24 +68,21 @@ class TestSimulatorFlowOptionsPassedAsDict:
 
     @pytest.mark.asyncio
     async def test_interactive_flow_charge_receives_dict(self, simulator, mock_device):
-        """Test interactive mode passes dict to flow_charge."""
-        # Mock aioconsole.ainput to simulate user selecting "1" (flow charge) then "0" (exit)
+        """User picks Flow charge, hits Enter to keep the configured idTag."""
         with patch('aioconsole.ainput', new_callable=AsyncMock) as mock_input:
-            mock_input.side_effect = ["1", "0"]
+            mock_input.side_effect = ["1", "", "0"]
             await simulator.loop_interactive()
 
-        # Verify flow_charge was called with the options dict directly
+        # Keeping the default idTag means we hand the device the same dict ref
         mock_device.flow_charge.assert_called_once_with(True, simulator.flow_charge_options)
 
     @pytest.mark.asyncio
     async def test_interactive_flow_authorize_receives_dict(self, simulator, mock_device):
-        """Test interactive mode passes dict to flow_authorize."""
-        # Mock aioconsole.ainput to simulate user selecting "3" (authorize) then "0" (exit)
+        """User picks Flow authorize, hits Enter to keep the configured idTag."""
         with patch('aioconsole.ainput', new_callable=AsyncMock) as mock_input:
-            mock_input.side_effect = ["3", "0"]
+            mock_input.side_effect = ["3", "", "0"]
             await simulator.loop_interactive()
 
-        # Verify flow_authorize was called with the options dict directly
         mock_device.flow_authorize.assert_called_once_with(simulator.flow_charge_options)
 
 
@@ -122,15 +119,19 @@ class TestSimulatorOptionsPersistence:
         assert id(simulator.flow_charge_options) == original_id
 
 
-class TestSimulatorRfidSwipe:
+class TestSimulatorFlowChargeWithCustomIdTag:
+    """Operator picks Flow charge and types a different idTag than the
+    configured default — emulates an RFID swipe of a different card."""
+
     @pytest.mark.asyncio
-    async def test_rfid_swipe_passes_entered_id_tag_without_mutating_config(self, simulator, mock_device):
+    async def test_overridden_id_tag_passes_through_without_mutating_config(
+            self, simulator, mock_device):
         original_options = simulator.flow_charge_options
         original_id = id(original_options)
         original_id_tag = original_options.get("idTag")
 
         with patch('aioconsole.ainput', new_callable=AsyncMock) as mock_input:
-            mock_input.side_effect = ["4", "RFID-SWIPED-TAG", "0"]
+            mock_input.side_effect = ["1", "RFID-SWIPED-TAG", "0"]
             await simulator.loop_interactive()
 
         mock_device.flow_charge.assert_called_once()
@@ -139,7 +140,17 @@ class TestSimulatorRfidSwipe:
         # Configured options must not be mutated
         assert simulator.flow_charge_options.get("idTag") == original_id_tag
         assert id(simulator.flow_charge_options) == original_id
-        # The swipe options were a copy, not the same dict
+        # An override produces a copy, not the same dict reference
+        assert passed_options is not simulator.flow_charge_options
+
+    @pytest.mark.asyncio
+    async def test_authorize_with_overridden_id_tag(self, simulator, mock_device):
+        with patch('aioconsole.ainput', new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["3", "OTHER-TAG", "0"]
+            await simulator.loop_interactive()
+
+        passed_options = mock_device.flow_authorize.call_args.args[0]
+        assert passed_options["idTag"] == "OTHER-TAG"
         assert passed_options is not simulator.flow_charge_options
 
 

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,0 +1,268 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import questionary
+
+from charge_device_simulator.device import utility
+
+
+CHOICES = ("Available", "Preparing", "Charging", "Faulted")
+
+
+class TestSelectFromListFallback:
+    """Non-TTY fallback path (the path tests, pytest CI, and piped input hit).
+
+    All tests force `_is_tty()` to False so questionary is never invoked."""
+
+    @pytest.mark.asyncio
+    async def test_numeric_index_resolves_to_choice(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["2"]
+            result = await utility.select_from_list("Pick:", CHOICES)
+        assert result == "Charging"
+
+    @pytest.mark.asyncio
+    async def test_literal_match_resolves_to_choice(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["Faulted"]
+            result = await utility.select_from_list("Pick:", CHOICES)
+        assert result == "Faulted"
+
+    @pytest.mark.asyncio
+    async def test_arbitrary_string_returned_when_allow_custom(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["MadeUpStatus"]
+            result = await utility.select_from_list(
+                "Pick:", CHOICES, allow_custom=True)
+        assert result == "MadeUpStatus"
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_reprompts_until_valid(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["Bogus", "Available"]
+            result = await utility.select_from_list(
+                "Pick:", CHOICES, allow_custom=False)
+        assert result == "Available"
+        assert mock_input.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_input_with_default_returns_default(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = [""]
+            result = await utility.select_from_list(
+                "Pick:", CHOICES, default="Available")
+        assert result == "Available"
+
+    @pytest.mark.asyncio
+    async def test_empty_input_without_default_reprompts(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["", "1"]
+            result = await utility.select_from_list("Pick:", CHOICES)
+        assert result == "Preparing"
+        assert mock_input.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_numeric_out_of_range_falls_through_to_custom(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["99"]
+            result = await utility.select_from_list("Pick:", CHOICES)
+        # "99" is not a valid index and not in choices, so allow_custom returns it as-is
+        assert result == "99"
+
+
+class TestSelectFromListTty:
+    """TTY path — mock questionary.select(...).ask_async() rather than driving
+    prompt_toolkit itself."""
+
+    @pytest.mark.asyncio
+    async def test_questionary_result_returned_directly(self):
+        question = MagicMock()
+        question.ask_async = AsyncMock(return_value="Charging")
+        with patch.object(utility, "_is_tty", return_value=True), \
+             patch("questionary.select", return_value=question) as mock_select:
+            result = await utility.select_from_list("Pick:", CHOICES)
+        assert result == "Charging"
+        # The "Other" sentinel should be appended when allow_custom=True
+        passed_choices = mock_select.call_args.kwargs["choices"]
+        assert utility._OTHER_SENTINEL in passed_choices
+
+    @pytest.mark.asyncio
+    async def test_other_sentinel_triggers_followup_input(self):
+        question = MagicMock()
+        question.ask_async = AsyncMock(return_value=utility._OTHER_SENTINEL)
+        with patch.object(utility, "_is_tty", return_value=True), \
+             patch("questionary.select", return_value=question), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.return_value = "MadeUpStatus"
+            result = await utility.select_from_list("Pick:", CHOICES)
+        assert result == "MadeUpStatus"
+        mock_input.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_other_sentinel_when_strict(self):
+        question = MagicMock()
+        question.ask_async = AsyncMock(return_value="Available")
+        with patch.object(utility, "_is_tty", return_value=True), \
+             patch("questionary.select", return_value=question) as mock_select:
+            await utility.select_from_list("Pick:", CHOICES, allow_custom=False)
+        passed_choices = mock_select.call_args.kwargs["choices"]
+        assert utility._OTHER_SENTINEL not in passed_choices
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_line_path_on_questionary_failure(self):
+        question = MagicMock()
+        question.ask_async = AsyncMock(side_effect=RuntimeError("no terminal"))
+        with patch.object(utility, "_is_tty", return_value=True), \
+             patch("questionary.select", return_value=question), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["1"]
+            result = await utility.select_from_list("Pick:", CHOICES)
+        assert result == "Preparing"
+
+
+class TestPromptText:
+    @pytest.mark.asyncio
+    async def test_non_tty_returns_input_verbatim(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.return_value = "RFID-12345"
+            result = await utility.prompt_text("Swipe:")
+        assert result == "RFID-12345"
+
+    @pytest.mark.asyncio
+    async def test_non_tty_blank_with_default_returns_default(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.return_value = ""
+            result = await utility.prompt_text("Connector:", default="1")
+        assert result == "1"
+
+    @pytest.mark.asyncio
+    async def test_non_tty_blank_without_default_returns_empty(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.return_value = ""
+            result = await utility.prompt_text("Optional:")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_tty_uses_questionary_text(self):
+        question = MagicMock()
+        question.ask_async = AsyncMock(return_value="42")
+        with patch.object(utility, "_is_tty", return_value=True), \
+             patch("questionary.text", return_value=question) as mock_text:
+            result = await utility.prompt_text("Connector:")
+        assert result == "42"
+        mock_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tty_falls_back_to_line_input_on_failure(self):
+        question = MagicMock()
+        question.ask_async = AsyncMock(side_effect=RuntimeError("no terminal"))
+        with patch.object(utility, "_is_tty", return_value=True), \
+             patch("questionary.text", return_value=question), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.return_value = "fallback-value"
+            result = await utility.prompt_text("Prompt:")
+        assert result == "fallback-value"
+
+
+class TestRunMenu:
+    @pytest.mark.asyncio
+    async def test_dispatches_handler_then_loops_until_back(self):
+        first_handler = AsyncMock()
+        second_handler = AsyncMock()
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["1", "2", "0"]
+            await utility.run_menu("Pick:", [
+                utility.MenuEntry("Back", is_back=True),
+                utility.MenuEntry("First", first_handler),
+                utility.MenuEntry("Second", second_handler),
+            ])
+        first_handler.assert_awaited_once()
+        second_handler.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_back_entry_with_no_handler_exits_immediately(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["0"]
+            await utility.run_menu("Pick:", [
+                utility.MenuEntry("Back", is_back=True),
+                utility.MenuEntry("Other", AsyncMock()),
+            ])
+        mock_input.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_label_match_dispatches(self):
+        handler = AsyncMock()
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["First", "Back"]
+            await utility.run_menu("Pick:", [
+                utility.MenuEntry("Back", is_back=True),
+                utility.MenuEntry("First", handler),
+            ])
+        handler.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shortcut_input_dispatches_handler(self):
+        handler = AsyncMock()
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["s", "0"]
+            await utility.run_menu("Pick:", [
+                utility.MenuEntry("Exit", is_back=True, shortcut="0"),
+                utility.MenuEntry("Single message", handler, shortcut="s"),
+            ])
+        handler.assert_awaited_once()
+
+
+class TestSelectFromListShortcuts:
+    @pytest.mark.asyncio
+    async def test_shortcut_input_resolves_to_choice_in_fallback(self):
+        with patch.object(utility, "_is_tty", return_value=False), \
+             patch("aioconsole.ainput", new_callable=AsyncMock) as mock_input:
+            mock_input.side_effect = ["s"]
+            result = await utility.select_from_list(
+                "Pick:",
+                ("Available", "Single"),
+                allow_custom=False,
+                shortcuts=("a", "s"),
+            )
+        assert result == "Single"
+
+    @pytest.mark.asyncio
+    async def test_tty_passes_questionary_choice_with_explicit_shortcut(self):
+        question = MagicMock()
+        question.ask_async = AsyncMock(return_value="Single")
+        with patch.object(utility, "_is_tty", return_value=True), \
+             patch("questionary.select", return_value=question) as mock_select:
+            await utility.select_from_list(
+                "Pick:",
+                ("Available", "Single"),
+                allow_custom=False,
+                shortcuts=("a", "s"),
+            )
+        passed_choices = mock_select.call_args.kwargs["choices"]
+        # When explicit shortcuts are supplied we build Choice objects, not raw strings
+        assert all(isinstance(c, questionary.Choice) for c in passed_choices)
+        assert [c.shortcut_key for c in passed_choices] == ["a", "s"]
+        # use_shortcuts must be True so questionary renders + binds the keys;
+        # explicit shortcut_key values are preserved (auto-assignment only fills
+        # in choices that don't already have one).
+        assert mock_select.call_args.kwargs["use_shortcuts"] is True
+
+    @pytest.mark.asyncio
+    async def test_mismatched_shortcuts_length_raises(self):
+        with pytest.raises(ValueError):
+            await utility.select_from_list(
+                "Pick:", ("a", "b"), shortcuts=("x",))


### PR DESCRIPTION
## Summary

End-to-end OCPP reservation support across 1.6 / 2.0.1 / OCPP-S, plus a substantial interactive-UI overhaul that grew out of dogfooding the new flows.

### Reservation flows (1.6, 2.0.1, OCPP-S)

- **Inbound `ReserveNow`**: validates against current state (`Rejected` if `connectorId` missing, `Occupied` if connector is busy or already reserved), stores reservation, then sends `StatusNotification("Reserved")`.
- **Inbound `CancelReservation`**: validates `reservationId` matches stored, clears state, then sends `StatusNotification("Available")`.
- **Reservation-aware charge start**: `flow_charge` now Authorize-then-validate. If the connector has an active reservation, the device must match by either the requested `idTag` directly or by `parentIdTag` (1.6) / `groupIdToken.idToken` (2.0.1) returned in the `Authorize` response. On match, `reservationId` is included in `StartTransaction` (1.6 / OCPP-S) or top-level of `TransactionEvent(Started)` (2.0.1) and the reservation is cleared. On no match, the charge is aborted and the reservation is preserved. The gate defaults `connectorId` to 1 to mirror `action_charge_start` so a missing key still applies the check.
- Reservation `expiryDate` is informational only (stored, not auto-expired).

### Interactive UI overhaul

- **Declarative menus** via new `MenuEntry` + `run_menu` helpers in `device/utility.py`. Replaces the copy-pasted `if/elif` loops in every device's `loop_interactive_custom` and the simulator's top-level `loop_interactive`.
- **Enum-aware picker** (`select_from_list`) — TTY renders a `questionary` arrow-key list with explicit shortcut keys; non-TTY (pytest, piped input) falls back to a numbered list. Wired into `StatusUpdate` prompts (J16 9-status + 16 error codes; J201 5-status; OCPP-S reuses 1.6 enums). Custom off-spec values still accepted.
- **`prompt_text` helper** wraps `questionary.text` (TTY) / `aioconsole.ainput` (non-TTY) so post-picker free-form prompts compose cleanly with the same stdin handoff (fixes hangs from prompt_toolkit/aioconsole interleaving).
- **`patch_stdout(raw=True)`** wraps every prompt so background log/websocket output renders above the menu (in color) instead of scrolling past it.
- **Shortcut keys** preserved from the legacy numeric muscle memory: `0` Back/Exit, `1`-`5` for ordinary entries, `s` for "Single message" / "Full custom" (replaces the old `99`).
- **Reservation interactive entries** on every device sub-menu: `Show reservation state`, `Make reservation (simulate ReserveNow)`, `Cancel reservation (simulate CancelReservation)` — three independent handler methods on `DeviceAbstract`.
- **Flow charge / Flow authorize** prompt for `idTag` with the configured one prefilled — Enter accepts the default, typing replaces it. Replaces the previous separate "Flow charge with RFID swipe" entry. The configured options dict is preserved (shallow-copied on override) so within-cycle state mutation by actions still works.

### Robustness fixes

- **No more crashes on rejected CSMS responses** in interactive mode. `Simulator.lifecycle_start` flips `device.error_exit = False` and `device.interactive_mode = True` when interactive — `handle_error` then returns False instead of `sys.exit(1)`, action methods propagate False, and the menu re-renders. Non-interactive / frequent-flow runs still fail-fast.
- **Action error messages now include the actual rejected response payload** so the operator can see what failed (e.g. `"Action Authorize Response Failed: [3, ..., {idTagInfo: {status: Invalid}}]"`). `handle_error` only attaches a traceback when there's actually a live exception (no more `NoneType: None` noise on protocol-level rejections).
- **Per-cycle option refresh in interactive mode**: each `Flow charge` invocation pops `chargeStartTime` / `chargeStopTime` / `meterStop` so the next cycle uses fresh "now" values instead of replaying the first cycle's. Frequent-flow / non-interactive runs are unaffected.
- **Strict typing** on every reservation/UI addition (`typing.Optional`, `typing.Dict`, `typing.Sequence`, etc.).
- New `requirements.txt` deps: `questionary>=2.0`.

## Test plan

- [x] `pytest tests/` — **116 tests pass** (8 pre-existing + 108 new across reservation flows, gate, inbound handlers, picker, prompt_text, run_menu, shortcuts, error-exit/interactive-mode toggles, and the missing-`connectorId` regression).
- [x] Reservation accept/reject paths verified for `ReserveNow` and `CancelReservation` on OCPP-J and OCPP-S.
- [x] `reservationId` plumbed into `StartTransaction` (1.6/OCPP-S) and at the top level of `TransactionEvent(Started)` (2.0.1) on idTag match and parent/group match.
- [x] `flow_charge` integration tests cover the gate-rejects path end-to-end for J16 and J201, plus the missing-`connectorId` regression that previously let mismatched tags through.
- [x] `interactive_reservation_show` / `_make` / `_cancel` covered directly.
- [x] `select_from_list` / `prompt_text` covered for TTY (questionary mocked), non-TTY fallback, custom values, strict mode, defaults, blank-input behavior, shortcut input, and questionary-failure fallback.
- [x] `run_menu` covered for handler dispatch, back-entry exit, label match, and shortcut input.
- [x] `Simulator.lifecycle_start` flips `error_exit` and `interactive_mode` correctly based on `is_interactive`.
- [ ] Manual end-to-end smoke against a real CSMS in a real terminal (deferred to reviewer): make/cancel a reservation, attempt to charge with a mismatched tag (should be locally rejected), with a matching tag (`reservationId` carried in `StartTransaction`), confirm Rejected `Authorize` no longer crashes the menu.