### PR TITLE
Make simulated sessions billable so Virta can complete them

### DIFF
--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -242,26 +242,44 @@ class DeviceAbstract(abc.ABC):
                 return last["meterValue"]
         return None
 
+    # Recorded inside the options dict itself so the record travels with the
+    # dict shared across cycles. Payload builders read specific keys only, so
+    # the extra entry never reaches the wire.
+    _PINNED_CHARGE_CYCLE_KEYS = "_pinnedChargeCycleKeys"
+    _CHARGE_CYCLE_EPHEMERAL_KEYS = ("chargeStartTime", "chargeStopTime", "meterStop", "meterStart")
+
     def _reset_charge_cycle_options(self, options: typing.Dict[str, typing.Any]) -> None:
-        """Drop per-cycle ephemeral keys so every flow_charge run picks up
-        fresh start/stop timestamps and a recomputed meterStop. The options
-        dict is shared across runs (frequent flows pass the configured dict by
-        reference), so without this every cycle after the first replays the
-        first cycle's chargeStartTime/chargeStopTime/meterStop — producing
+        """Drop the previous cycle's auto-filled values so every flow_charge
+        run picks up fresh start/stop timestamps and a recomputed meterStop,
+        while preserving values the operator configured. The options dict is
+        shared across runs (frequent flows pass the configured dict by
+        reference), so without the reset every cycle after the first replays
+        the first cycle's chargeStartTime/chargeStopTime/meterStop — producing
         overlapping transactions whose meterStop contradicts the periodic
-        meter values, which billing backends reject. The previous cycle's
-        meterStop is carried into meterStart so the energy register stays
-        monotonic like a real meter — except when a scripted meterValues list
-        is configured: its readings are absolute and replay identically each
-        cycle, so carrying the stop forward would put meterStart above the
-        replayed samples (a register rewind); the configured meterStart is
-        kept instead. reservationId is always dropped: the reservation gate
-        injects it per cycle, and replaying it would attach an
-        already-consumed reservation to the next StartTransaction."""
-        if "meterStop" in options and self._scripted_final_meter_value(options) is None:
+        meter values, which billing backends reject. But the operator may pin
+        any of those keys (plus meterStart) up front to replay a deterministic
+        session: the first call records which ephemeral keys are already
+        present, and every call drops only the unpinned ones. The previous
+        cycle's meterStop is carried into meterStart so the energy register
+        stays monotonic like a real meter — skipped when either meter key is
+        pinned (the configured session shape wins) or a scripted meterValues
+        list is configured: its readings are absolute and replay identically
+        each cycle, so carrying the stop forward would put meterStart above
+        the replayed samples (a register rewind). reservationId is always
+        dropped: the reservation gate injects it per cycle, and replaying it
+        would attach an already-consumed reservation to the next
+        StartTransaction."""
+        pinned = options.get(self._PINNED_CHARGE_CYCLE_KEYS)
+        if pinned is None:
+            pinned = tuple(key for key in self._CHARGE_CYCLE_EPHEMERAL_KEYS if key in options)
+            options[self._PINNED_CHARGE_CYCLE_KEYS] = pinned
+        if ("meterStop" in options
+                and "meterStop" not in pinned and "meterStart" not in pinned
+                and self._scripted_final_meter_value(options) is None):
             options["meterStart"] = options["meterStop"]
         for key in ("chargeStartTime", "chargeStopTime", "meterStop"):
-            options.pop(key, None)
+            if key not in pinned:
+                options.pop(key, None)
         options.pop("reservationId", None)
 
     def _consume_reservation_if_used(self, options: typing.Dict[str, typing.Any]) -> None:

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -65,8 +65,12 @@ class DeviceAbstract(abc.ABC):
             return False
         pass
 
-    def by_device_req_resp_timeout(self) -> str:
-        return f'"response timeout, {self.response_timeout_seconds} seconds passed"'
+    def by_device_req_resp_timeout(self) -> None:
+        # None makes callers treat the timeout as a failed request; anything
+        # truthy would let actions that only check `is None` log success for
+        # a request the middleware never answered.
+        self.logger.warning(f"Response timeout, {self.response_timeout_seconds} seconds passed")
+        return None
 
     @abc.abstractmethod
     async def action_register(self) -> bool:

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -19,11 +19,6 @@ class DeviceAbstract(abc.ABC):
         self.name: str = ''
         self.charge_in_progress: bool = False
         self.charge_id: typing.Any = -1
-        # Set True by Simulator.lifecycle_start when running an interactive
-        # session. Enables UX-only behaviors (e.g. refreshing per-cycle
-        # ephemeral options on each flow_charge); never affects non-interactive
-        # / frequent-flow runs.
-        self.interactive_mode: bool = False
         self.reservation_id: typing.Optional[int] = None
         self.reservation_connector_id: typing.Optional[int] = None
         self.reservation_id_tag: typing.Optional[str] = None
@@ -229,14 +224,17 @@ class DeviceAbstract(abc.ABC):
         return False
 
     def _reset_charge_cycle_options(self, options: typing.Dict[str, typing.Any]) -> None:
-        """In interactive mode only, drop per-cycle ephemeral keys so a re-run
-        of flow_charge picks up fresh start/stop timestamps and a recomputed
-        meterStop. Without this, a second Flow charge in the same interactive
-        session would replay the first cycle's `chargeStartTime` because the
-        dict is shared. Frequent-flow / non-interactive runs are intentionally
-        unaffected — they construct their own options each loop iteration."""
-        if not self.interactive_mode:
-            return
+        """Drop per-cycle ephemeral keys so every flow_charge run picks up
+        fresh start/stop timestamps and a recomputed meterStop. The options
+        dict is shared across runs (frequent flows pass the configured dict by
+        reference), so without this every cycle after the first replays the
+        first cycle's chargeStartTime/chargeStopTime/meterStop — producing
+        overlapping transactions whose meterStop contradicts the periodic
+        meter values, which billing backends reject. The previous cycle's
+        meterStop is carried into meterStart so the energy register stays
+        monotonic like a real meter."""
+        if "meterStop" in options:
+            options["meterStart"] = options["meterStop"]
         for key in ("chargeStartTime", "chargeStopTime", "meterStop"):
             options.pop(key, None)
 

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -130,10 +130,14 @@ class DeviceAbstract(abc.ABC):
                                and 'secondsToSleep' in i
                                for i in meter_values)):
                 raise ValueError("meterValues must be a list of dictionaries with 'meterValue', 'timestamp' and 'secondsToSleep' keys.")
+            # Baseline for the delivered-sample record: with zero samples
+            # delivered the session reported no energy beyond meterStart.
+            options[self._LAST_SENT_SCRIPTED_METER_VALUE] = options.get("meterStart")
             for i in meter_values:
                 await asyncio.sleep(i["secondsToSleep"])
                 if not await self.action_meter_value(options, meter_value=i["meterValue"], time_stamp=i["timestamp"]):
                     return False
+                options[self._LAST_SENT_SCRIPTED_METER_VALUE] = i["meterValue"]
             return True
         else:
             charge_loop_wait_seconds = options.get("autoActionsLoopDelayInSeconds", 15)
@@ -242,10 +246,25 @@ class DeviceAbstract(abc.ABC):
                 return last["meterValue"]
         return None
 
+    def _scripted_stop_meter_value(self, options: typing.Dict[str, typing.Any]) -> typing.Optional[int]:
+        """Register reading the stop payload should carry for a scripted
+        meterValues session, or None when no script is configured. Prefers the
+        last sample the ongoing loop actually delivered: when a send fails
+        mid-script the remaining samples never went out, and a meterStop above
+        the last delivered reading would bill energy the session never
+        reported. Falls back to the script's final value when the loop hasn't
+        run (direct action_charge_stop calls)."""
+        scripted_final = self._scripted_final_meter_value(options)
+        if scripted_final is None:
+            return None
+        last_sent = options.get(self._LAST_SENT_SCRIPTED_METER_VALUE)
+        return last_sent if last_sent is not None else scripted_final
+
     # Recorded inside the options dict itself so the record travels with the
     # dict shared across cycles. Payload builders read specific keys only, so
     # the extra entry never reaches the wire.
     _PINNED_CHARGE_CYCLE_KEYS = "_pinnedChargeCycleKeys"
+    _LAST_SENT_SCRIPTED_METER_VALUE = "_lastSentScriptedMeterValue"
     _CHARGE_CYCLE_EPHEMERAL_KEYS = ("chargeStartTime", "chargeStopTime", "meterStop", "meterStart")
 
     def _reset_charge_cycle_options(self, options: typing.Dict[str, typing.Any]) -> None:
@@ -281,6 +300,9 @@ class DeviceAbstract(abc.ABC):
             if key not in pinned:
                 options.pop(key, None)
         options.pop("reservationId", None)
+        # Per-cycle delivery record; a stale value would make the next cycle's
+        # stop reading repeat the previous cycle's last delivered sample.
+        options.pop(self._LAST_SENT_SCRIPTED_METER_VALUE, None)
 
     def _consume_reservation_if_used(self, options: typing.Dict[str, typing.Any]) -> None:
         if "reservationId" in options and self.reservation_is_active() \

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -255,11 +255,14 @@ class DeviceAbstract(abc.ABC):
         is configured: its readings are absolute and replay identically each
         cycle, so carrying the stop forward would put meterStart above the
         replayed samples (a register rewind); the configured meterStart is
-        kept instead."""
+        kept instead. reservationId is always dropped: the reservation gate
+        injects it per cycle, and replaying it would attach an
+        already-consumed reservation to the next StartTransaction."""
         if "meterStop" in options and self._scripted_final_meter_value(options) is None:
             options["meterStart"] = options["meterStop"]
         for key in ("chargeStartTime", "chargeStopTime", "meterStop"):
             options.pop(key, None)
+        options.pop("reservationId", None)
 
     def _consume_reservation_if_used(self, options: typing.Dict[str, typing.Any]) -> None:
         if "reservationId" in options and self.reservation_is_active() \

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -177,7 +177,12 @@ class DeviceAbstract(abc.ABC):
     def reserve_can_accept(self, connector_id: typing.Optional[int]) -> bool:
         if self.charge_in_progress:
             return False
-        if self.reservation_is_active() and self.reservation_connector_id == connector_id:
+        # The device stores a single reservation, so accepting another while
+        # one is active — same connector, a different one, or connector 0,
+        # which reserves the charge point as a whole — would silently
+        # overwrite the stored record and drop the protection the first
+        # Accepted promised.
+        if self.reservation_is_active():
             return False
         return True
 

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -202,15 +202,18 @@ class DeviceAbstract(abc.ABC):
         self.reservation_expiry_date = None
 
     def _pre_charge_reservation_gate(self, options: typing.Dict[str, typing.Any]) -> bool:
-        """If the connector has an active reservation, validate the most recent
-        authorize info against it (direct idTag or parent/group match). On match,
-        injects reservationId into options so the start payload carries it."""
+        """If an active reservation covers the requested connector — stored on
+        that connector, or on connector 0, which in OCPP 1.6 reserves the
+        charge point as a whole and so applies to every connector — validate
+        the most recent authorize info against it (direct idTag or
+        parent/group match). On match, injects reservationId into options so
+        the start payload carries it."""
         # Mirror action_charge_start's default — a missing connectorId would
         # otherwise compare None against the stored connector and silently
         # skip the gate (letting a non-matching tag through on a reserved
         # connector).
         connector_id = options.get("connectorId", 1)
-        if not self.reservation_is_active() or self.reservation_connector_id != connector_id:
+        if not self.reservation_is_active() or self.reservation_connector_id not in (0, connector_id):
             return True
         requested_id_tag = options.get("idTag")
         if requested_id_tag is not None and requested_id_tag == self.reservation_id_tag:

--- a/src/charge_device_simulator/device/abstract.py
+++ b/src/charge_device_simulator/device/abstract.py
@@ -227,6 +227,18 @@ class DeviceAbstract(abc.ABC):
             f"{self.reservation_id} on connector {connector_id}")
         return False
 
+    @staticmethod
+    def _scripted_final_meter_value(options: typing.Dict[str, typing.Any]) -> typing.Optional[int]:
+        """Last register reading of a scripted meterValues list, if one is
+        configured. The stop reading must repeat it — a meterStop computed
+        from wall-clock time would contradict the samples already sent."""
+        meter_values = options.get("meterValues")
+        if isinstance(meter_values, list) and meter_values:
+            last = meter_values[-1]
+            if isinstance(last, dict) and "meterValue" in last:
+                return last["meterValue"]
+        return None
+
     def _reset_charge_cycle_options(self, options: typing.Dict[str, typing.Any]) -> None:
         """Drop per-cycle ephemeral keys so every flow_charge run picks up
         fresh start/stop timestamps and a recomputed meterStop. The options
@@ -236,8 +248,12 @@ class DeviceAbstract(abc.ABC):
         overlapping transactions whose meterStop contradicts the periodic
         meter values, which billing backends reject. The previous cycle's
         meterStop is carried into meterStart so the energy register stays
-        monotonic like a real meter."""
-        if "meterStop" in options:
+        monotonic like a real meter — except when a scripted meterValues list
+        is configured: its readings are absolute and replay identically each
+        cycle, so carrying the stop forward would put meterStart above the
+        replayed samples (a register rewind); the configured meterStart is
+        kept instead."""
+        if "meterStop" in options and self._scripted_final_meter_value(options) is None:
             options["meterStart"] = options["meterStop"]
         for key in ("chargeStartTime", "chargeStopTime", "meterStop"):
             options.pop(key, None)

--- a/src/charge_device_simulator/device/ensto/device_ensto.py
+++ b/src/charge_device_simulator/device/ensto/device_ensto.py
@@ -145,7 +145,9 @@ class DeviceEnsto(device_abstract.DeviceAbstract):
         if "chargeStopTime" not in options:
             options["chargeStopTime"] = self.utcnow_iso()
         if "meterStop" not in options:
-            options["meterStop"] = self.charge_meter_value_current(options)
+            scripted_final = self._scripted_final_meter_value(options)
+            options["meterStop"] = (scripted_final if scripted_final is not None
+                                    else self.charge_meter_value_current(options))
 
     async def action_charge_start(self, options: dict) -> bool:
         action = "charge_start"

--- a/src/charge_device_simulator/device/ensto/device_ensto.py
+++ b/src/charge_device_simulator/device/ensto/device_ensto.py
@@ -184,7 +184,7 @@ class DeviceEnsto(device_abstract.DeviceAbstract):
             "out": options.get("connectorId", 1),
             "time": self.utcnow().timestamp() if time_stamp is None else time_stamp,
             "t": 382,
-            "eem": (meter_value if meter_value else self.charge_meter_value_current(options)) - options["meterStart"],
+            "eem": (meter_value if meter_value is not None else self.charge_meter_value_current(options)) - options["meterStart"],
         }
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or 'chk' not in resp_json or 'ack' not in resp_json:

--- a/src/charge_device_simulator/device/ensto/device_ensto.py
+++ b/src/charge_device_simulator/device/ensto/device_ensto.py
@@ -232,6 +232,7 @@ class DeviceEnsto(device_abstract.DeviceAbstract):
     async def flow_charge(self, auto_stop: bool, options: dict) -> bool:
         log_title = self.flow_charge.__name__
         self.logger.info(f"Flow {log_title} Start")
+        self._reset_charge_cycle_options(options)
         if not options.get("is_remote_started", False):
             if not await self.action_authorize(options):
                 self.charge_in_progress = False

--- a/src/charge_device_simulator/device/ensto/device_ensto.py
+++ b/src/charge_device_simulator/device/ensto/device_ensto.py
@@ -145,8 +145,8 @@ class DeviceEnsto(device_abstract.DeviceAbstract):
         if "chargeStopTime" not in options:
             options["chargeStopTime"] = self.utcnow_iso()
         if "meterStop" not in options:
-            scripted_final = self._scripted_final_meter_value(options)
-            options["meterStop"] = (scripted_final if scripted_final is not None
+            scripted_stop = self._scripted_stop_meter_value(options)
+            options["meterStop"] = (scripted_stop if scripted_stop is not None
                                     else self.charge_meter_value_current(options))
 
     async def action_charge_start(self, options: dict) -> bool:

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -107,7 +107,7 @@ class AbstractDeviceOcppJ(DeviceAbstract):
         pass
 
     async def action_heart_beat(self) -> bool:
-        action = "HeartBeat"
+        action = "Heartbeat"
         self.logger.info(f"Action {action} Start")
         if await self.by_device_req_send(action, {}) is None:
             return False
@@ -170,13 +170,16 @@ class AbstractDeviceOcppJ(DeviceAbstract):
         if not self._pre_charge_reservation_gate(options):
             self.charge_in_progress = False
             return False
+        # Preparing precedes StartTransaction: the connector reaches that state
+        # when the cable is plugged and the tag accepted, before the
+        # transaction exists.
+        if not await self.action_status_update("Preparing", options):
+            self.charge_in_progress = False
+            return False
         if not await self.action_charge_start(options):
             self.charge_in_progress = False
             return False
         self._consume_reservation_if_used(options)
-        if not await self.action_status_update("Preparing", options):
-            self.charge_in_progress = False
-            return False
         if not await self.action_status_update("Charging", options):
             self.charge_in_progress = False
             return False
@@ -344,7 +347,9 @@ class AbstractDeviceOcppJ(DeviceAbstract):
                 resp_payload["status"] = "Rejected"
             else:
                 options = {
-                    "connectorId": req_payload["connectorId"] if "connectorId" in req_payload else 0,
+                    # connectorId 0 addresses the charge point as a whole and
+                    # is not a valid transaction target; fall back to 1.
+                    "connectorId": req_payload.get("connectorId") or 1,
                     "idTag": req_payload["idTag"] if "idTag" in req_payload else "-",
                 }
                 self.logger.info(f"Device, Read, Request, RemoteStart, Options: {json.dumps(options)}")

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -180,23 +180,19 @@ class AbstractDeviceOcppJ(DeviceAbstract):
             self.charge_in_progress = False
             return False
         self._consume_reservation_if_used(options)
-        if not await self.action_status_update("Charging", options):
-            self.charge_in_progress = False
-            return False
-        if not await self.flow_charge_ongoing_loop(auto_stop, options):
-            self.charge_in_progress = False
-            return False
-        if not await self.action_status_update("Finishing", options):
-            self.charge_in_progress = False
-            return False
-        if not await self.action_charge_stop(options):
-            self.charge_in_progress = False
-            return False
-        if not await self.action_status_update("Available", options):
-            self.charge_in_progress = False
+        # The backend opened a transaction at StartTransaction; from here on a
+        # failed step must not skip StopTransaction, or the session is left
+        # open server-side (never billed/completed) while charge_can_stop
+        # rejects any later RemoteStopTransaction.
+        ok = await self.action_status_update("Charging", options)
+        ok = await self.flow_charge_ongoing_loop(auto_stop, options) and ok
+        ok = await self.action_status_update("Finishing", options) and ok
+        ok = await self.action_charge_stop(options) and ok
+        ok = await self.action_status_update("Available", options) and ok
+        self.charge_in_progress = False
+        if not ok:
             return False
         self.logger.info(f"Flow {log_title} End")
-        self.charge_in_progress = False
         return True
 
     async def flow_charge_ongoing_actions(self, options: dict) -> bool:

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -220,11 +220,20 @@ class AbstractDeviceOcppJ(DeviceAbstract):
             return await asyncio.wait_for(result, timeout=self.response_timeout_seconds)
         except asyncio.TimeoutError:
             return self.by_device_req_resp_timeout()
+        finally:
+            # Drop the entry on timeout/cancellation too, so a late reply is
+            # logged as an orphan instead of resolving a dead future, and the
+            # class-level dict doesn't grow with every unanswered request.
+            self.__pending_by_device_reqs.pop(req_id, None)
 
     def __by_device_req_resp_ready(self, future: asyncio.Future, action, resp_json):
         resp = json.dumps(resp_json)
         self.logger.debug(f"By Device Req ({action}) Resp:\n{resp}")
-        future.set_result(resp_json)
+        # The future is cancelled if the reply lands in the same loop iteration
+        # that asyncio.wait_for timed out; set_result would then raise
+        # InvalidStateError inside the websocket read loop and kill it.
+        if not future.done():
+            future.set_result(resp_json)
         pass
 
     async def __loop_internal(self):

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -134,7 +134,9 @@ class AbstractDeviceOcppJ(DeviceAbstract):
         if "chargeStopTime" not in options:
             options["chargeStopTime"] = self.utcnow_iso()
         if "meterStop" not in options:
-            options["meterStop"] = self.charge_meter_value_current(options)
+            scripted_final = self._scripted_final_meter_value(options)
+            options["meterStop"] = (scripted_final if scripted_final is not None
+                                    else self.charge_meter_value_current(options))
 
     def charge_meter_value_current(self, options: dict):
         self.fill_missing_options_charge_start(options)

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -134,8 +134,8 @@ class AbstractDeviceOcppJ(DeviceAbstract):
         if "chargeStopTime" not in options:
             options["chargeStopTime"] = self.utcnow_iso()
         if "meterStop" not in options:
-            scripted_final = self._scripted_final_meter_value(options)
-            options["meterStop"] = (scripted_final if scripted_final is not None
+            scripted_stop = self._scripted_stop_meter_value(options)
+            options["meterStop"] = (scripted_stop if scripted_stop is not None
                                     else self.charge_meter_value_current(options))
 
     def charge_meter_value_current(self, options: dict):

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -179,6 +179,10 @@ class AbstractDeviceOcppJ(DeviceAbstract):
             self.charge_in_progress = False
             return False
         if not await self.action_charge_start(options):
+            # Preparing was already announced above; without this best-effort
+            # rollback a rejected StartTransaction leaves the connector shown
+            # as Preparing on the CSMS forever.
+            await self.action_status_update("Available", options)
             self.charge_in_progress = False
             return False
         self._consume_reservation_if_used(options)

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -341,7 +341,7 @@ class AbstractDeviceOcppJ(DeviceAbstract):
                 resp_payload = {
                     "status": "Accepted"
                 }
-                next_async_task = await self.action_heart_beat()
+                next_async_task = self.action_heart_beat()
             if req_payload["requestedMessage"] == "StatusNotification":
                 options = {
                     "connectorId": req_payload["connectorId"] if "connectorId" in req_payload else 0,
@@ -350,9 +350,9 @@ class AbstractDeviceOcppJ(DeviceAbstract):
                     "status": "Accepted"
                 }
                 if self.charge_in_progress:
-                    next_async_task = await self.action_status_update("Charging", options)
+                    next_async_task = self.action_status_update("Charging", options)
                 else:
-                    next_async_task = await self.action_status_update("Available", options)
+                    next_async_task = self.action_status_update("Available", options)
         if req_action == "RemoteStartTransaction".lower():
             if not self.charge_can_start():
                 resp_payload["status"] = "Rejected"

--- a/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
+++ b/src/charge_device_simulator/device/ocpp_j/abstract_device_ocpp_j.py
@@ -253,6 +253,19 @@ class AbstractDeviceOcppJ(DeviceAbstract):
                         self.logger.warning(f"Device Read, Response, Not found the request, Id: {read_resp_id}, Message:\n{read_raw}")
                         continue
                     read_resp_callable(read_as_json)
+                elif read_type == MessageTypes.RespError.value:  # The middleware rejected a request we sent
+                    if len(read_as_json) < 2:
+                        self.logger.warning(f"Device Read, Response Error, Invalid, Message:\n{read_raw}")
+                        continue
+                    read_resp_id = str(read_as_json[1])
+                    self.logger.error(f"Device Read, Response Error, Id: {read_resp_id}, Message:\n{read_raw}")
+                    read_resp_callable = self.__pending_by_device_reqs.pop(read_resp_id, None)
+                    if read_resp_callable is None:
+                        self.logger.warning(f"Device Read, Response Error, Not found the request, Id: {read_resp_id}")
+                        continue
+                    # Resolve as None so the waiting action reports failure
+                    # rather than blocking until the response timeout.
+                    read_resp_callable(None)
                 else:
                     self.logger.debug(f"Device Read, Type Unknown, Message:\n{read_raw}")
         except asyncio.CancelledError:

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -121,7 +121,6 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
         conenctor_id = options.get("connectorId", 1)
         json_payload = {
             "connectorId": conenctor_id,
-            "transactionId": self.charge_id,
             "meterValue": [{
                 "timestamp": time_stamp if time_stamp else self.utcnow_iso(),
                 # OCPP 1.6J types sampledValue.value as a string; sending a
@@ -135,6 +134,11 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
                 }]
             }]
         }
+        # transactionId is optional and only meaningful while a transaction is
+        # open; outside one charge_id holds -1 or the previous session's id,
+        # which schema-strict backends reject or misattribute.
+        if self.charge_id != -1:
+            json_payload["transactionId"] = self.charge_id
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None:
             return False
@@ -173,6 +177,7 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
                 f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
                 ErrorReasons.InvalidResponse)
             return False
+        self.charge_id = -1
         self.logger.info(f"Action {action} End")
         return True
 

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -171,7 +171,14 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
                 }]
             }]
         }
-        resp_json = await self.by_device_req_send(action, json_payload)
+        try:
+            resp_json = await self.by_device_req_send(action, json_payload)
+        finally:
+            # The local transaction context is dead once a stop has been
+            # attempted, whatever the conf says — there is no retry path, and
+            # a kept id would let a later triggered MeterValues re-attach the
+            # dead transaction.
+            self.charge_id = -1
         if resp_json is None or len(resp_json) != 3 or not isinstance(resp_json[2], dict):
             await self.handle_error(
                 f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
@@ -187,7 +194,6 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
         if id_tag_info is not None and id_tag_info.get('status') != 'Accepted':
             self.logger.warning(
                 f"Action {action} idTagInfo status not Accepted (transaction still stopped):\n{json.dumps(id_tag_info)}")
-        self.charge_id = -1
         self.logger.info(f"Action {action} End")
         return True
 

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -124,8 +124,10 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
             "transactionId": self.charge_id,
             "meterValue": [{
                 "timestamp": time_stamp if time_stamp else self.utcnow_iso(),
+                # OCPP 1.6J types sampledValue.value as a string; sending a
+                # bare number makes schema-validating backends drop the sample.
                 "sampledValue": [{
-                    "value": meter_value if meter_value else self.charge_meter_value_current(options),
+                    "value": str(meter_value if meter_value else self.charge_meter_value_current(options)),
                     "context": "Sample.Periodic",
                     "measurand": "Energy.Active.Import.Register",
                     "location": "Outlet",
@@ -150,7 +152,20 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
             "transactionId": self.charge_id,
             "meterStop": options["meterStop"],
             "idTag": id_tag,
-            "reason": options.get("stopReason", "Local")
+            "reason": options.get("stopReason", "Local"),
+            # Backends build the CDR from the closing register reading; without
+            # a Transaction.End sample some cannot price the session and leave
+            # it closed-but-unbilled.
+            "transactionData": [{
+                "timestamp": options["chargeStopTime"],
+                "sampledValue": [{
+                    "value": str(options["meterStop"]),
+                    "context": "Transaction.End",
+                    "measurand": "Energy.Active.Import.Register",
+                    "location": "Outlet",
+                    "unit": "Wh"
+                }]
+            }]
         }
         resp_json = await self.by_device_req_send(action, json_payload)
         if resp_json is None or len(resp_json) != 3 or resp_json[2][key_name]['status'] != 'Accepted':

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -127,7 +127,7 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
                 # OCPP 1.6J types sampledValue.value as a string; sending a
                 # bare number makes schema-validating backends drop the sample.
                 "sampledValue": [{
-                    "value": str(meter_value if meter_value else self.charge_meter_value_current(options)),
+                    "value": str(meter_value if meter_value is not None else self.charge_meter_value_current(options)),
                     "context": "Sample.Periodic",
                     "measurand": "Energy.Active.Import.Register",
                     "location": "Outlet",

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j16.py
@@ -172,11 +172,21 @@ class DeviceOcppJ16(AbstractDeviceOcppJ):
             }]
         }
         resp_json = await self.by_device_req_send(action, json_payload)
-        if resp_json is None or len(resp_json) != 3 or resp_json[2][key_name]['status'] != 'Accepted':
+        if resp_json is None or len(resp_json) != 3 or not isinstance(resp_json[2], dict):
             await self.handle_error(
                 f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
                 ErrorReasons.InvalidResponse)
             return False
+        # idTagInfo is optional in StopTransaction.conf, and its status is
+        # authorization info about the idTag (e.g. Blocked for future use) —
+        # not whether the stop was registered. The CSMS closes the transaction
+        # the moment it answers the CALL, so any valid CALLRESULT is a
+        # successful stop; treating `[3, id, {}]` as failure crashed the flow
+        # and skipped the closing Available status.
+        id_tag_info = resp_json[2].get(key_name)
+        if id_tag_info is not None and id_tag_info.get('status') != 'Accepted':
+            self.logger.warning(
+                f"Action {action} idTagInfo status not Accepted (transaction still stopped):\n{json.dumps(id_tag_info)}")
         self.charge_id = -1
         self.logger.info(f"Action {action} End")
         return True

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -261,6 +261,10 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
             self.charge_in_progress = False
             return False
         if not await self.action_charge_start(options):
+            # Occupied was already announced above; without this best-effort
+            # rollback a rejected transaction start leaves the connector shown
+            # as Occupied on the CSMS forever.
+            await self.action_status_update("Available", options)
             self.charge_in_progress = False
             return False
         self._consume_reservation_if_used(options)

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -154,6 +154,14 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
     async def action_meter_value(self, options: dict, meter_value: int = None, time_stamp: datetime = None) -> bool:
         action = "MeterValues"
         self.logger.info(f"Action {action} Start")
+        if self.charge_id == -1:
+            # TransactionEvent Updated must reference an open transaction;
+            # sending one outside a transaction (e.g. a triggered MeterValues
+            # after the session ended) would replay the previous transaction's
+            # id. Idle 2.0.1 readings belong in a MeterValues message, which
+            # this simulator does not implement.
+            self.logger.info(f"Action {action} skipped, no open transaction")
+            return True
         evse_id = options.get("evseId", 1)
         conenctor_id = options.get("connectorId", 1)
         self.charge_seq_no += 1
@@ -238,7 +246,14 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
                 "type":"ISO14443"
             }
         }
-        resp_json = await self.by_device_req_send(action, json_payload)
+        try:
+            resp_json = await self.by_device_req_send(action, json_payload)
+        finally:
+            # The local transaction context is dead once an Ended event has
+            # been attempted, whatever the response says — there is no retry
+            # path, and a kept id would let a later triggered MeterValues
+            # replay the dead transaction's UUID.
+            self.charge_id = -1
         if resp_json is None or len(resp_json) != 3 or not isinstance(resp_json[2], dict):
             await self.handle_error(
                 f"Action {action} Response Failed:\n{json.dumps(resp_json)}",

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -264,17 +264,17 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
             self.charge_in_progress = False
             return False
         self._consume_reservation_if_used(options)
-        if not await self.flow_charge_ongoing_loop(auto_stop, options):
-            self.charge_in_progress = False
-            return False
-        if not await self.action_charge_stop(options):
-            self.charge_in_progress = False
-            return False
-        if not await self.action_status_update("Available", options):
-            self.charge_in_progress = False
+        # The backend opened a transaction at StartTransaction; from here on a
+        # failed step must not skip StopTransaction, or the session is left
+        # open server-side (never billed/completed) while charge_can_stop
+        # rejects any later RemoteStopTransaction.
+        ok = await self.flow_charge_ongoing_loop(auto_stop, options)
+        ok = await self.action_charge_stop(options) and ok
+        ok = await self.action_status_update("Available", options) and ok
+        self.charge_in_progress = False
+        if not ok:
             return False
         self.logger.info(f"Flow {log_title} End")
-        self.charge_in_progress = False
         return True
 
     def _reserve_now_options_from_payload(

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -171,7 +171,7 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
                 {
                     "sampledValue": [
                         {
-                            "value": meter_value if meter_value else self.charge_meter_value_current(options),
+                            "value": meter_value if meter_value is not None else self.charge_meter_value_current(options),
                             "context":"Sample.Periodic",
                             "measurand": "Energy.Active.Import.Register",
                             "location": "Outlet",

--- a/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
+++ b/src/charge_device_simulator/device/ocpp_j/device_ocpp_j201.py
@@ -239,11 +239,19 @@ class DeviceOcppJ201(AbstractDeviceOcppJ):
             }
         }
         resp_json = await self.by_device_req_send(action, json_payload)
-        if resp_json is None or resp_json[2][key_name]['status'] != 'Accepted':
+        if resp_json is None or len(resp_json) != 3 or not isinstance(resp_json[2], dict):
             await self.handle_error(
                 f"Action {action} Response Failed:\n{json.dumps(resp_json)}",
                 ErrorReasons.InvalidResponse)
             return False
+        # idTokenInfo is optional in TransactionEventResponse and concerns the
+        # token, not whether the Ended event was registered — an empty payload
+        # is the common success response. Any valid CALLRESULT closes the
+        # transaction.
+        id_token_info = resp_json[2].get(key_name)
+        if id_token_info is not None and id_token_info.get('status') != 'Accepted':
+            self.logger.warning(
+                f"Action {action} idTokenInfo status not Accepted (transaction still ended):\n{json.dumps(id_token_info)}")
         self.logger.info(f"Action {action} End")
         return True
 

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -207,8 +207,8 @@ class DeviceOcppS(DeviceAbstract):
         if "chargeStopTime" not in options:
             options["chargeStopTime"] = self.utcnow_iso()
         if "meterStop" not in options:
-            scripted_final = self._scripted_final_meter_value(options)
-            options["meterStop"] = (scripted_final if scripted_final is not None
+            scripted_stop = self._scripted_stop_meter_value(options)
+            options["meterStop"] = (scripted_stop if scripted_stop is not None
                                     else self.charge_meter_value_current(options))
 
     async def action_charge_start(self, options: dict) -> bool:

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -207,7 +207,9 @@ class DeviceOcppS(DeviceAbstract):
         if "chargeStopTime" not in options:
             options["chargeStopTime"] = self.utcnow_iso()
         if "meterStop" not in options:
-            options["meterStop"] = self.charge_meter_value_current(options)
+            scripted_final = self._scripted_final_meter_value(options)
+            options["meterStop"] = (scripted_final if scripted_final is not None
+                                    else self.charge_meter_value_current(options))
 
     async def action_charge_start(self, options: dict) -> bool:
         action = "StartTransaction"

--- a/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
+++ b/src/charge_device_simulator/device/ocpp_s/device_ocpp_s.py
@@ -250,7 +250,7 @@ class DeviceOcppS(DeviceAbstract):
             "transactionId": self.charge_id,
             "values": [{
                 "timestamp": time_stamp if time_stamp else self.utcnow_iso(),
-                "value": [meter_value if meter_value else self.charge_meter_value_current(options), {
+                "value": [meter_value if meter_value is not None else self.charge_meter_value_current(options), {
                     "context": "Sample.Periodic",
                     "measurand": "Energy.Active.Import.Register",
                     "location": "Outlet",

--- a/src/charge_device_simulator/device/simulator.py
+++ b/src/charge_device_simulator/device/simulator.py
@@ -108,14 +108,11 @@ class Simulator:
 
     async def lifecycle_start(self):
         # Interactive sessions should drop back to the menu on a rejected
-        # response instead of sys.exit'ing the process, and need a few UX-only
-        # tweaks gated by `interactive_mode` (e.g. per-cycle option resets).
-        # Toggled here (rather than in initialize) so callers can flip
-        # is_interactive after initialize() completes; common pattern in
-        # play_ground.py.
+        # response instead of sys.exit'ing the process. Toggled here (rather
+        # than in initialize) so callers can flip is_interactive after
+        # initialize() completes; common pattern in play_ground.py.
         if self.is_interactive:
             self.device.error_exit = False
-            self.device.interactive_mode = True
         tasks = []
         if self.is_interactive:
             tasks.append(self.loop_interactive())

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -569,6 +569,43 @@ class TestCallErrorAndTimeoutAreFailures:
         ocpp_j_device._ws.send = AsyncMock()
 
         assert await ocpp_j_device.by_device_req_send("Heartbeat", {}) is None
+        # The timed-out request must not leak its pending entry: a late reply
+        # would find it and resolve a future wait_for already cancelled.
+        assert self._pending(ocpp_j_device) == {}
+
+    @pytest.mark.asyncio
+    async def test_late_reply_after_timeout_does_not_kill_read_loop(self, ocpp_j_device):
+        """A CALLRESULT/CALLERROR landing after the timeout is an orphan;
+        resolving the cancelled future instead raised InvalidStateError inside
+        the read loop, silently killing it while the socket stayed open."""
+        ocpp_j_device.response_timeout_seconds = 0
+        sent_frames = []
+        ocpp_j_device._ws = MagicMock()
+        ocpp_j_device._ws.send = AsyncMock(side_effect=lambda raw: sent_frames.append(raw))
+
+        assert await ocpp_j_device.by_device_req_send("Heartbeat", {}) is None
+        req_id = json.loads(sent_frames[0])[1]
+
+        drained = asyncio.Event()
+        late_frames = [
+            json.dumps([3, req_id, {"currentTime": "now"}]),
+            json.dumps([4, req_id, "GenericError", "late rejection", {}]),
+        ]
+
+        async def fake_recv():
+            if late_frames:
+                return late_frames.pop(0)
+            drained.set()
+            await asyncio.Event().wait()  # nothing more to deliver
+
+        ocpp_j_device._ws.recv = AsyncMock(side_effect=fake_recv)
+        loop_task = asyncio.create_task(
+            ocpp_j_device._AbstractDeviceOcppJ__loop_internal())
+        try:
+            await asyncio.wait_for(drained.wait(), timeout=2)
+            assert not loop_task.done()
+        finally:
+            loop_task.cancel()
 
     @pytest.mark.asyncio
     async def test_meter_values_reports_failure_on_timeout(self, device_ocpp_j16):

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -389,10 +389,9 @@ class TestConsumeReservationIfUsed:
 
 
 class TestResetChargeCycleOptions:
-    """A second `flow_charge` invocation in an interactive session must not
-    replay the previous cycle's start/stop time or computed meterStop. The
-    same reset must NOT happen in non-interactive (frequent-flow) runs to
-    preserve historical behavior."""
+    """Every `flow_charge` invocation must start a fresh cycle: replaying the
+    previous cycle's start/stop time or meterStop produces overlapping
+    transactions whose stop reading contradicts the periodic meter values."""
 
     def _stale_options(self):
         return {
@@ -404,8 +403,7 @@ class TestResetChargeCycleOptions:
             "meterStart": 1000,
         }
 
-    def test_drops_stale_charge_cycle_keys_when_interactive(self, ocpp_j_device):
-        ocpp_j_device.interactive_mode = True
+    def test_drops_stale_charge_cycle_keys(self, ocpp_j_device):
         options = self._stale_options()
 
         ocpp_j_device._reset_charge_cycle_options(options)
@@ -413,17 +411,24 @@ class TestResetChargeCycleOptions:
         assert "chargeStartTime" not in options
         assert "chargeStopTime" not in options
         assert "meterStop" not in options
-        # Caller-supplied config (idTag, connectorId, meterStart) is untouched
-        assert options == {"idTag": "ABC", "connectorId": 1, "meterStart": 1000}
+        assert options["idTag"] == "ABC"
+        assert options["connectorId"] == 1
 
-    def test_keeps_options_when_not_interactive(self, ocpp_j_device):
-        # Default (interactive_mode=False) — frequent-flow / non-interactive run
+    def test_carries_previous_meter_stop_into_meter_start(self, ocpp_j_device):
+        """The energy register never rewinds between sessions on real hardware."""
         options = self._stale_options()
-        snapshot = dict(options)
 
         ocpp_j_device._reset_charge_cycle_options(options)
 
-        assert options == snapshot
+        assert options["meterStart"] == 31000
+
+    def test_keeps_meter_start_on_first_cycle(self, ocpp_j_device):
+        """No previous cycle (no meterStop) leaves the configured start alone."""
+        options = {"idTag": "ABC", "connectorId": 1, "meterStart": 1000}
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        assert options == {"idTag": "ABC", "connectorId": 1, "meterStart": 1000}
 
 
 class TestInteractiveReservationHandlers:

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -419,21 +419,27 @@ class TestConsumeReservationIfUsed:
 
 class TestResetChargeCycleOptions:
     """Every `flow_charge` invocation must start a fresh cycle: replaying the
-    previous cycle's start/stop time or meterStop produces overlapping
-    transactions whose stop reading contradicts the periodic meter values."""
+    previous cycle's auto-filled start/stop time or meterStop produces
+    overlapping transactions whose stop reading contradicts the periodic meter
+    values. Values the operator pinned up front are the exception — they
+    describe a deterministic session and must survive every cycle."""
 
-    def _stale_options(self):
-        return {
-            "idTag": "ABC",
-            "connectorId": 1,
+    def _stale_options(self, device):
+        """Options as they look after an unpinned first cycle: the reset
+        recorded no operator-pinned keys, fill_missing_* then added the
+        cycle's values."""
+        options = {"idTag": "ABC", "connectorId": 1}
+        device._reset_charge_cycle_options(options)
+        options.update({
             "chargeStartTime": "2025-01-15T12:00:00+00:00",
             "chargeStopTime": "2025-01-15T12:30:00+00:00",
             "meterStop": 31000,
             "meterStart": 1000,
-        }
+        })
+        return options
 
     def test_drops_stale_charge_cycle_keys(self, ocpp_j_device):
-        options = self._stale_options()
+        options = self._stale_options(ocpp_j_device)
 
         ocpp_j_device._reset_charge_cycle_options(options)
 
@@ -445,7 +451,7 @@ class TestResetChargeCycleOptions:
 
     def test_carries_previous_meter_stop_into_meter_start(self, ocpp_j_device):
         """The energy register never rewinds between sessions on real hardware."""
-        options = self._stale_options()
+        options = self._stale_options(ocpp_j_device)
 
         ocpp_j_device._reset_charge_cycle_options(options)
 
@@ -457,7 +463,50 @@ class TestResetChargeCycleOptions:
 
         ocpp_j_device._reset_charge_cycle_options(options)
 
-        assert options == {"idTag": "ABC", "connectorId": 1, "meterStart": 1000}
+        assert options["idTag"] == "ABC"
+        assert options["connectorId"] == 1
+        assert options["meterStart"] == 1000
+
+    def test_pinned_session_shape_survives_consecutive_resets(self, ocpp_j_device):
+        """Operator-configured replay values must reach the wire on the first
+        cycle and every one after — including the very first reset, which used
+        to discard them before they were ever sent."""
+        options = {
+            "idTag": "ABC",
+            "connectorId": 1,
+            "meterStart": 1000,
+            "meterStop": 5000,
+            "chargeStartTime": "2025-01-01T00:00:00+00:00",
+            "chargeStopTime": "2025-01-01T01:00:00+00:00",
+        }
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        # The carry must not clobber the pinned meterStart with meterStop.
+        assert options["meterStart"] == 1000
+        assert options["meterStop"] == 5000
+        assert options["chargeStartTime"] == "2025-01-01T00:00:00+00:00"
+        assert options["chargeStopTime"] == "2025-01-01T01:00:00+00:00"
+
+    def test_auto_filled_keys_still_dropped_when_meter_start_is_pinned(self, ocpp_j_device):
+        """Only keys present before the first cycle are pinned; values filled
+        in during a cycle are still dropped and recomputed the next cycle, and
+        the carry from an auto-filled meterStop must not clobber the pin."""
+        options = {"idTag": "ABC", "meterStart": 1000}
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+        options.update({
+            "chargeStartTime": "2025-01-15T12:00:00+00:00",
+            "chargeStopTime": "2025-01-15T12:30:00+00:00",
+            "meterStop": 31000,
+        })
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        assert "chargeStartTime" not in options
+        assert "chargeStopTime" not in options
+        assert "meterStop" not in options
+        assert options["meterStart"] == 1000
 
     def test_drops_gate_injected_reservation_id(self, ocpp_j_device):
         """reservationId is per-cycle state injected by the reservation gate;
@@ -470,18 +519,38 @@ class TestResetChargeCycleOptions:
         assert "reservationId" not in options
 
     def test_scripted_meter_values_keep_configured_meter_start(self, ocpp_j_device):
-        """Scripted registers are absolute and replay identically each cycle;
-        carrying the previous stop into meterStart would put it above the
-        replayed samples — a register rewind."""
+        """A meterStart pinned alongside a scripted meterValues list survives
+        the cycle whose stop reading was auto-filled from the script."""
         options = {
             "meterStart": 1000,
-            "meterStop": 2000,
             "meterValues": [
                 {"meterValue": 1500, "timestamp": "t1", "secondsToSleep": 0},
                 {"meterValue": 2000, "timestamp": "t2", "secondsToSleep": 0},
             ],
         }
 
+        ocpp_j_device._reset_charge_cycle_options(options)
+        options["meterStop"] = 2000  # filled from the script during the cycle
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        assert options["meterStart"] == 1000
+        assert "meterStop" not in options
+
+    def test_scripted_meter_values_skip_carry_even_when_unpinned(self, ocpp_j_device):
+        """Scripted registers are absolute and replay identically each cycle;
+        carrying the previous stop into meterStart would put it above the
+        replayed samples — a register rewind. Holds even when meterStart was
+        auto-filled rather than pinned."""
+        options = {
+            "meterValues": [
+                {"meterValue": 1500, "timestamp": "t1", "secondsToSleep": 0},
+                {"meterValue": 2000, "timestamp": "t2", "secondsToSleep": 0},
+            ],
+        }
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+        options["meterStart"] = 1000  # auto-filled during the cycle
+        options["meterStop"] = 2000
         ocpp_j_device._reset_charge_cycle_options(options)
 
         assert options["meterStart"] == 1000

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -369,6 +369,33 @@ class TestPreChargeReservationGate:
         assert ocpp_j_device._pre_charge_reservation_gate(options) is False
         assert "reservationId" not in options
 
+    def test_connector_zero_reservation_blocks_wrong_tag_on_any_connector(self, ocpp_j_device):
+        # OCPP 1.6: connectorId 0 in ReserveNow reserves the charge point as
+        # a whole, so the gate must apply it to whichever connector the
+        # charge requests.
+        _seed_reservation(ocpp_j_device, reservation_id=20, connector_id=0, id_tag="OWNER")
+        options = {"connectorId": 1, "idTag": "INTRUDER"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is False
+        assert "reservationId" not in options
+
+    def test_connector_zero_reservation_blocks_wrong_tag_when_connector_id_missing(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=21, connector_id=0, id_tag="OWNER")
+        options = {"idTag": "INTRUDER"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is False
+        assert "reservationId" not in options
+
+    def test_connector_zero_reservation_matching_tag_injects_reservation_id(self, ocpp_j_device):
+        _seed_reservation(ocpp_j_device, reservation_id=22, connector_id=0, id_tag="OWNER")
+        options = {"connectorId": 1, "idTag": "OWNER"}
+
+        assert ocpp_j_device._pre_charge_reservation_gate(options) is True
+        assert options["reservationId"] == 22
+        # The requested connector still goes out in the start payload; the
+        # gate must not rewrite it to the reservation's connector 0.
+        assert options["connectorId"] == 1
+
 
 class TestConsumeReservationIfUsed:
     def test_clears_when_reservation_id_in_options_matches(self, ocpp_j_device):

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -1,4 +1,6 @@
+import asyncio
 import datetime
+import json
 import math
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -502,6 +504,88 @@ class TestInteractiveReservationHandlers:
             await ocpp_j_device.interactive_reservation_cancel()
 
         ocpp_j_device.flow_reservation_cancel.assert_awaited_once_with(999)
+
+
+class TestCallErrorAndTimeoutAreFailures:
+    """A CALLERROR (message type 4) used to fall through to the "Type Unknown"
+    branch, leaving the request to time out; the timeout in turn returned a
+    truthy string, so actions that only check `is None` logged success for
+    messages the middleware had rejected."""
+
+    def _pending(self, device):
+        return device._AbstractDeviceOcppJ__pending_by_device_reqs
+
+    async def _run_with_inbound(self, device, frame_for):
+        """Send one request while a reader loop answers it with `frame_for(req_id)`."""
+        device.response_timeout_seconds = 5
+        sent = asyncio.Event()
+        device._ws = MagicMock()
+        device._ws.send = AsyncMock(side_effect=lambda raw: sent.set())
+
+        answered = False
+
+        async def fake_recv():
+            nonlocal answered
+            await sent.wait()
+            if answered:
+                await asyncio.Event().wait()  # nothing more to deliver
+            answered = True
+            return frame_for(next(iter(self._pending(device))))
+
+        device._ws.recv = AsyncMock(side_effect=fake_recv)
+        loop_task = asyncio.create_task(
+            device._AbstractDeviceOcppJ__loop_internal())
+        try:
+            return await device.by_device_req_send("Heartbeat", {})
+        finally:
+            loop_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_call_error_resolves_request_as_none(self, ocpp_j_device):
+        result = await self._run_with_inbound(
+            ocpp_j_device,
+            lambda req_id: json.dumps(
+                [4, req_id, "SecurityError", "Rejected by CSMS", {}]),
+        )
+
+        assert result is None
+        # The pending entry is cleared, not left to leak until timeout
+        assert self._pending(ocpp_j_device) == {}
+
+    @pytest.mark.asyncio
+    async def test_call_result_still_resolves_normally(self, ocpp_j_device):
+        result = await self._run_with_inbound(
+            ocpp_j_device,
+            lambda req_id: json.dumps([3, req_id, {"currentTime": "now"}]),
+        )
+
+        assert result is not None
+        assert result[2] == {"currentTime": "now"}
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_none(self, ocpp_j_device):
+        ocpp_j_device.response_timeout_seconds = 0
+        ocpp_j_device._ws = MagicMock()
+        ocpp_j_device._ws.send = AsyncMock()
+
+        assert await ocpp_j_device.by_device_req_send("Heartbeat", {}) is None
+
+    @pytest.mark.asyncio
+    async def test_meter_values_reports_failure_on_timeout(self, device_ocpp_j16):
+        """The action must not log success for an unanswered request."""
+        device_ocpp_j16.response_timeout_seconds = 0
+
+        ok = await device_ocpp_j16.action_meter_value({"connectorId": 1}, meter_value=100)
+
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_status_notification_reports_failure_on_timeout(self, device_ocpp_j16):
+        device_ocpp_j16.response_timeout_seconds = 0
+
+        ok = await device_ocpp_j16.action_status_update("Charging", {"connectorId": 1})
+
+        assert ok is False
 
 
 class TestInboundReserveNowCancelReservation:

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -459,6 +459,16 @@ class TestResetChargeCycleOptions:
 
         assert options == {"idTag": "ABC", "connectorId": 1, "meterStart": 1000}
 
+    def test_drops_gate_injected_reservation_id(self, ocpp_j_device):
+        """reservationId is per-cycle state injected by the reservation gate;
+        replaying it would attach an already-consumed reservation to the next
+        StartTransaction."""
+        options = {"idTag": "ABC", "reservationId": 7}
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        assert "reservationId" not in options
+
     def test_scripted_meter_values_keep_configured_meter_start(self, ocpp_j_device):
         """Scripted registers are absolute and replay identically each cycle;
         carrying the previous stop into meterStart would put it above the

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -271,6 +271,39 @@ class TestFlowReserve:
         assert ocpp_j_device.reservation_id == 1
         ocpp_j_device.action_status_update.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_rejected_when_charge_point_reserved_via_connector_zero(self, ocpp_j_device):
+        """A connector-0 reservation covers the charge point as a whole; a
+        later ReserveNow for a specific connector must not silently overwrite
+        it and strip the reserved tag's protection."""
+        _seed_reservation(ocpp_j_device, reservation_id=1, connector_id=0)
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+
+        result = await ocpp_j_device.flow_reserve({
+            "reservationId": 99, "connectorId": 1, "idTag": "OTHER"
+        })
+
+        assert result is False
+        assert ocpp_j_device.reservation_id == 1
+        assert ocpp_j_device.reservation_connector_id == 0
+        ocpp_j_device.action_status_update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejected_on_other_connector_while_a_reservation_is_active(self, ocpp_j_device):
+        """The device stores a single reservation; accepting one for a
+        different connector would silently drop the stored record."""
+        _seed_reservation(ocpp_j_device, reservation_id=1, connector_id=1)
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+
+        result = await ocpp_j_device.flow_reserve({
+            "reservationId": 99, "connectorId": 2, "idTag": "OTHER"
+        })
+
+        assert result is False
+        assert ocpp_j_device.reservation_id == 1
+        assert ocpp_j_device.reservation_connector_id == 1
+        ocpp_j_device.action_status_update.assert_not_awaited()
+
 
 class TestFlowReservationCancel:
     @pytest.mark.asyncio

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -782,6 +782,47 @@ class TestCallErrorAndTimeoutAreFailures:
         assert ok is False
 
 
+class TestTriggerMessageDoesNotBlockReader:
+    """The TriggerMessage branches must schedule the resulting action as a
+    task, not await it inline: by_middleware_req runs inside the websocket
+    read loop, and the action's own response can only be delivered by that
+    same loop — awaiting deadlocks until the response timeout, after which
+    asyncio.create_task(False) raises TypeError and kills the reader."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_trigger_schedules_action_as_task(self, ocpp_j_device):
+        ocpp_j_device.by_middleware_req_response_ready = AsyncMock()
+        ocpp_j_device.action_heart_beat = AsyncMock(return_value=True)
+
+        await ocpp_j_device.by_middleware_req(
+            "req1", "triggermessage", {"requestedMessage": "Heartbeat"})
+
+        # The handler must return without having awaited the action inline...
+        ocpp_j_device.action_heart_beat.assert_not_awaited()
+        resp = ocpp_j_device.by_middleware_req_response_ready.await_args.args[1]
+        assert resp == {"status": "Accepted"}
+        # ...and the scheduled task runs once the loop gets control back.
+        await asyncio.sleep(0)
+        ocpp_j_device.action_heart_beat.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_status_trigger_schedules_action_as_task(self, ocpp_j_device):
+        ocpp_j_device.by_middleware_req_response_ready = AsyncMock()
+        ocpp_j_device.action_status_update = AsyncMock(return_value=True)
+        ocpp_j_device.charge_in_progress = True
+
+        await ocpp_j_device.by_middleware_req(
+            "req1", "triggermessage",
+            {"requestedMessage": "StatusNotification", "connectorId": 2})
+
+        ocpp_j_device.action_status_update.assert_not_awaited()
+        await asyncio.sleep(0)
+        ocpp_j_device.action_status_update.assert_awaited_once()
+        args = ocpp_j_device.action_status_update.await_args.args
+        assert args[0] == "Charging"
+        assert args[1]["connectorId"] == 2
+
+
 class TestInboundReserveNowCancelReservation:
     """Tests for the by_middleware_req routing of ReserveNow / CancelReservation.
 

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -432,6 +432,57 @@ class TestResetChargeCycleOptions:
 
         assert options == {"idTag": "ABC", "connectorId": 1, "meterStart": 1000}
 
+    def test_scripted_meter_values_keep_configured_meter_start(self, ocpp_j_device):
+        """Scripted registers are absolute and replay identically each cycle;
+        carrying the previous stop into meterStart would put it above the
+        replayed samples — a register rewind."""
+        options = {
+            "meterStart": 1000,
+            "meterStop": 2000,
+            "meterValues": [
+                {"meterValue": 1500, "timestamp": "t1", "secondsToSleep": 0},
+                {"meterValue": 2000, "timestamp": "t2", "secondsToSleep": 0},
+            ],
+        }
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        assert options["meterStart"] == 1000
+        assert "meterStop" not in options
+
+
+class TestScriptedMeterValuesStopReading:
+    """The stop reading must repeat the script's final register value; a
+    wall-clock-computed meterStop contradicts the samples already sent and
+    makes the session unbillable."""
+
+    def test_meter_stop_defaults_to_last_scripted_value(self, ocpp_j_device):
+        options = {
+            "meterStart": 1000,
+            "chargeStartTime": "2025-01-15T12:00:00+00:00",
+            "meterValues": [
+                {"meterValue": 1500, "timestamp": "t1", "secondsToSleep": 0},
+                {"meterValue": 2000, "timestamp": "t2", "secondsToSleep": 0},
+            ],
+        }
+
+        ocpp_j_device.fill_missing_options_charge_stop(options)
+
+        assert options["meterStop"] == 2000
+
+    def test_explicit_meter_stop_still_wins_over_script(self, ocpp_j_device):
+        options = {
+            "meterStop": 9999,
+            "chargeStopTime": "2025-01-15T12:30:00+00:00",
+            "meterValues": [
+                {"meterValue": 2000, "timestamp": "t", "secondsToSleep": 0},
+            ],
+        }
+
+        ocpp_j_device.fill_missing_options_charge_stop(options)
+
+        assert options["meterStop"] == 9999
+
 
 class TestInteractiveReservationHandlers:
     @pytest.mark.asyncio

--- a/tests/test_abstract_device_ocpp_j.py
+++ b/tests/test_abstract_device_ocpp_j.py
@@ -518,6 +518,22 @@ class TestResetChargeCycleOptions:
 
         assert "reservationId" not in options
 
+    def test_drops_delivered_sample_record(self, ocpp_j_device):
+        """The delivered-sample record is per-cycle state written by the
+        ongoing loop; a stale value would make the next cycle's stop reading
+        repeat the previous cycle's last delivered sample."""
+        record_key = ocpp_j_device._LAST_SENT_SCRIPTED_METER_VALUE
+        options = {
+            "meterValues": [
+                {"meterValue": 1500, "timestamp": "t1", "secondsToSleep": 0},
+            ],
+            record_key: 1500,
+        }
+
+        ocpp_j_device._reset_charge_cycle_options(options)
+
+        assert record_key not in options
+
     def test_scripted_meter_values_keep_configured_meter_start(self, ocpp_j_device):
         """A meterStart pinned alongside a scripted meterValues list survives
         the cycle whose stop reading was auto-filled from the script."""
@@ -588,6 +604,42 @@ class TestScriptedMeterValuesStopReading:
         ocpp_j_device.fill_missing_options_charge_stop(options)
 
         assert options["meterStop"] == 9999
+
+    @pytest.mark.asyncio
+    async def test_meter_stop_repeats_last_delivered_sample_after_mid_script_failure(self, ocpp_j_device):
+        """When a send fails mid-script the remaining samples never go out;
+        a meterStop taken from the script's final value would bill energy the
+        session never reported."""
+        options = {
+            "meterStart": 1000,
+            "chargeStartTime": "2025-01-15T12:00:00+00:00",
+            "meterValues": [
+                {"meterValue": 1500, "timestamp": "t1", "secondsToSleep": 0},
+                {"meterValue": 10000, "timestamp": "t2", "secondsToSleep": 0},
+            ],
+        }
+        ocpp_j_device.action_meter_value = AsyncMock(side_effect=[True, False])
+
+        assert await ocpp_j_device.flow_charge_ongoing_loop(True, options) is False
+        ocpp_j_device.fill_missing_options_charge_stop(options)
+
+        assert options["meterStop"] == 1500
+
+    @pytest.mark.asyncio
+    async def test_meter_stop_falls_back_to_meter_start_when_no_sample_was_delivered(self, ocpp_j_device):
+        options = {
+            "meterStart": 1000,
+            "chargeStartTime": "2025-01-15T12:00:00+00:00",
+            "meterValues": [
+                {"meterValue": 1500, "timestamp": "t1", "secondsToSleep": 0},
+            ],
+        }
+        ocpp_j_device.action_meter_value = AsyncMock(return_value=False)
+
+        assert await ocpp_j_device.flow_charge_ongoing_loop(True, options) is False
+        ocpp_j_device.fill_missing_options_charge_stop(options)
+
+        assert options["meterStop"] == 1000
 
 
 class TestInteractiveReservationHandlers:

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -265,6 +265,59 @@ class TestJ16StopTransactionPayload:
             payload["transactionData"][0]["sampledValue"][0]["value"]
 
 
+class TestJ16StopTransactionConfHandling:
+    """idTagInfo is optional in StopTransaction.conf and concerns the idTag's
+    future authorization, not whether the stop was registered. An empty conf
+    `[3, id, {}]` is valid and used to raise KeyError, crashing the flow and
+    skipping the closing Available status."""
+
+    def _options(self):
+        return {"connectorId": 1, "idTag": "X", "meterStart": 1000,
+                "meterStop": 2000, "chargeStopTime": "2025-01-15T12:30:00+00:00"}
+
+    @pytest.mark.asyncio
+    async def test_empty_conf_is_a_successful_stop(self, device_ocpp_j16):
+        device_ocpp_j16.charge_id = 555
+        device_ocpp_j16.by_device_req_send = AsyncMock(return_value=[3, "r", {}])
+
+        ok = await device_ocpp_j16.action_charge_stop(self._options())
+
+        assert ok is True
+        assert device_ocpp_j16.charge_id == -1
+
+    @pytest.mark.asyncio
+    async def test_non_accepted_id_tag_info_still_stops(self, device_ocpp_j16):
+        """A Blocked/Invalid verdict is about the tag, not the stop."""
+        device_ocpp_j16.charge_id = 555
+        device_ocpp_j16.by_device_req_send = AsyncMock(
+            return_value=[3, "r", {"idTagInfo": {"status": "Blocked"}}])
+
+        ok = await device_ocpp_j16.action_charge_stop(self._options())
+
+        assert ok is True
+        assert device_ocpp_j16.charge_id == -1
+
+    @pytest.mark.asyncio
+    async def test_timeout_or_call_error_still_fails(self, device_ocpp_j16):
+        device_ocpp_j16.error_exit = False
+        device_ocpp_j16.charge_id = 555
+        device_ocpp_j16.by_device_req_send = AsyncMock(return_value=None)
+
+        ok = await device_ocpp_j16.action_charge_stop(self._options())
+
+        assert ok is False
+        assert device_ocpp_j16.charge_id == 555
+
+    @pytest.mark.asyncio
+    async def test_malformed_conf_still_fails(self, device_ocpp_j16):
+        device_ocpp_j16.error_exit = False
+        device_ocpp_j16.by_device_req_send = AsyncMock(return_value=[3, "r"])
+
+        ok = await device_ocpp_j16.action_charge_stop(self._options())
+
+        assert ok is False
+
+
 class TestJ16ChargeCycleIsolation:
     """The regression behind Virta sessions staying CLOSED: consecutive
     frequent-flow charges shared one options dict, so every cycle after the

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -317,6 +317,47 @@ class TestJ16MidFlowFailureStillStops:
         assert "StopTransaction" not in actions
 
 
+class TestJ16ScriptedMeterValuesFlow:
+    @pytest.mark.asyncio
+    async def test_stop_repeats_last_scripted_sample_across_cycles(self, device_ocpp_j16, no_sleep):
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append((action, payload))
+            if action == "StartTransaction":
+                return _stub_start_transaction_response()
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+        options = {
+            "connectorId": 1, "idTag": "X", "meterStart": 1000,
+            "meterValues": [
+                {"meterValue": 1500, "timestamp": "2025-01-15T12:10:00+00:00",
+                 "secondsToSleep": 0},
+                {"meterValue": 2000, "timestamp": "2025-01-15T12:20:00+00:00",
+                 "secondsToSleep": 0},
+            ],
+        }
+
+        await device_ocpp_j16.flow_charge(True, options)
+        first_stop = [p for a, p in sent if a == "StopTransaction"][0]
+
+        sent.clear()
+        await device_ocpp_j16.flow_charge(True, options)
+        second_start = [p for a, p in sent if a == "StartTransaction"][0]
+        second_stop = [p for a, p in sent if a == "StopTransaction"][0]
+
+        # The stop reading repeats the script's final register value, in both
+        # meterStop and the Transaction.End sample
+        assert first_stop["meterStop"] == 2000
+        assert first_stop["transactionData"][0]["sampledValue"][0]["value"] == "2000"
+        # The script replays identically each cycle: meterStart stays at the
+        # configured value instead of carrying the previous stop above the
+        # replayed samples
+        assert second_start["meterStart"] == 1000
+        assert second_stop["meterStop"] == 2000
+
+
 class TestJ16FlowReserveStatusPayload:
     @pytest.mark.asyncio
     async def test_reserved_status_uses_1_6_status_field(self, device_ocpp_j16):

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -129,6 +129,67 @@ class TestJ16FlowChargeReservationGate:
         assert device_ocpp_j16.reservation_is_active()
 
 
+class TestJ16MeterValuesPayload:
+    @pytest.mark.asyncio
+    async def test_sampled_value_is_a_string(self, device_ocpp_j16):
+        """OCPP 1.6J types sampledValue.value as a string."""
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return [3, "req-1", {}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        await device_ocpp_j16.action_meter_value({"connectorId": 1}, meter_value=2500)
+
+        sampled = captured["MeterValues"]["meterValue"][0]["sampledValue"][0]
+        assert sampled["value"] == "2500"
+
+
+class TestJ16StopTransactionPayload:
+    async def _capture_stop(self, device, options):
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}}]
+
+        device.by_device_req_send = AsyncMock(side_effect=fake_send)
+        await device.action_charge_stop(options)
+        return captured["StopTransaction"]
+
+    @pytest.mark.asyncio
+    async def test_includes_transaction_end_sample(self, device_ocpp_j16):
+        """Backends build the CDR from the closing register reading."""
+        payload = await self._capture_stop(device_ocpp_j16, {
+            "connectorId": 1,
+            "idTag": "X",
+            "meterStart": 1000,
+            "meterStop": 3500,
+            "chargeStopTime": "2025-01-15T12:30:00+00:00",
+        })
+
+        sampled = payload["transactionData"][0]["sampledValue"][0]
+        assert sampled["value"] == "3500"
+        assert sampled["context"] == "Transaction.End"
+        assert sampled["measurand"] == "Energy.Active.Import.Register"
+        assert payload["transactionData"][0]["timestamp"] == payload["timestamp"]
+
+    @pytest.mark.asyncio
+    async def test_meter_stop_matches_transaction_data(self, device_ocpp_j16):
+        """A mismatch between the two is what makes a session unbillable."""
+        payload = await self._capture_stop(device_ocpp_j16, {
+            "connectorId": 1,
+            "idTag": "X",
+            "meterStart": 1000,
+            "chargeStartTime": "2025-01-15T12:00:00+00:00",
+        })
+
+        assert str(payload["meterStop"]) == \
+            payload["transactionData"][0]["sampledValue"][0]["value"]
+
+
 class TestJ16ChargeCycleIsolation:
     """The regression behind Virta sessions staying CLOSED: consecutive
     frequent-flow charges shared one options dict, so every cycle after the
@@ -169,6 +230,29 @@ class TestJ16ChargeCycleIsolation:
         # register never rewinds
         assert second_start["meterStart"] == first_stop["meterStop"]
         assert second_stop["meterStop"] >= second_start["meterStart"]
+
+    @pytest.mark.asyncio
+    async def test_preparing_precedes_start_transaction(self, device_ocpp_j16, no_sleep):
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append((action, payload.get("status")))
+            if action == "StartTransaction":
+                return _stub_start_transaction_response()
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        await device_ocpp_j16.flow_charge(True, {
+            "connectorId": 1, "idTag": "X",
+            "autoActionsLoopDelayInSeconds": 0, "autoActionsLoopCount": 1,
+        })
+
+        actions = [a for a, _ in sent]
+        statuses = [s for a, s in sent if a == "StatusNotification"]
+        assert actions.index("StartTransaction") > \
+            next(i for i, (a, s) in enumerate(sent) if s == "Preparing")
+        assert statuses[:2] == ["Preparing", "Charging"]
 
 
 class TestJ16FlowReserveStatusPayload:

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -255,6 +255,68 @@ class TestJ16ChargeCycleIsolation:
         assert statuses[:2] == ["Preparing", "Charging"]
 
 
+class TestJ16MidFlowFailureStillStops:
+    """Once StartTransaction is accepted the backend holds an open session; a
+    mid-flow failure (timeouts and CALLERRORs resolve to None) must still send
+    StopTransaction, or the session is orphaned server-side — stuck open and
+    never billed — while RemoteStopTransaction gets rejected because
+    charge_in_progress was already cleared."""
+
+    async def _run_flow(self, device, fail_when):
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append((action, payload))
+            if fail_when(action, payload):
+                return None  # what a timeout or CALLERROR resolves to
+            if action == "StartTransaction":
+                return _stub_start_transaction_response()
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}}]
+
+        device.by_device_req_send = AsyncMock(side_effect=fake_send)
+        ok = await device.flow_charge(True, {
+            "connectorId": 1, "idTag": "X",
+            "autoActionsLoopDelayInSeconds": 0, "autoActionsLoopCount": 1,
+        })
+        return ok, [a for a, _ in sent]
+
+    @pytest.mark.asyncio
+    async def test_charging_status_failure_still_sends_stop(self, device_ocpp_j16, no_sleep):
+        ok, actions = await self._run_flow(
+            device_ocpp_j16,
+            lambda a, p: a == "StatusNotification" and p.get("status") == "Charging")
+
+        assert ok is False
+        assert "StopTransaction" in actions
+        assert device_ocpp_j16.charge_in_progress is False
+
+    @pytest.mark.asyncio
+    async def test_meter_values_failure_still_sends_stop(self, device_ocpp_j16, no_sleep):
+        ok, actions = await self._run_flow(
+            device_ocpp_j16, lambda a, p: a == "MeterValues")
+
+        assert ok is False
+        assert "StopTransaction" in actions
+
+    @pytest.mark.asyncio
+    async def test_finishing_status_failure_still_sends_stop(self, device_ocpp_j16, no_sleep):
+        ok, actions = await self._run_flow(
+            device_ocpp_j16,
+            lambda a, p: a == "StatusNotification" and p.get("status") == "Finishing")
+
+        assert ok is False
+        assert "StopTransaction" in actions
+
+    @pytest.mark.asyncio
+    async def test_no_stop_when_start_transaction_never_succeeded(self, device_ocpp_j16, no_sleep):
+        device_ocpp_j16.error_exit = False
+        ok, actions = await self._run_flow(
+            device_ocpp_j16, lambda a, p: a == "StartTransaction")
+
+        assert ok is False
+        assert "StopTransaction" not in actions
+
+
 class TestJ16FlowReserveStatusPayload:
     @pytest.mark.asyncio
     async def test_reserved_status_uses_1_6_status_field(self, device_ocpp_j16):

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -164,6 +164,63 @@ class TestJ16MeterValuesPayload:
         sampled = captured["MeterValues"]["meterValue"][0]["sampledValue"][0]
         assert sampled["value"] == "0"
 
+    @pytest.mark.asyncio
+    async def test_idle_meter_values_omits_transaction_id(self, device_ocpp_j16):
+        """TriggerMessage(MeterValues) while no transaction is open must not
+        send the placeholder transactionId -1."""
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return [3, "req-1", {}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        await device_ocpp_j16.action_meter_value({"connectorId": 1}, meter_value=100)
+
+        assert "transactionId" not in captured["MeterValues"]
+
+    @pytest.mark.asyncio
+    async def test_meter_values_during_transaction_include_transaction_id(self, device_ocpp_j16):
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return [3, "req-1", {}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+        device_ocpp_j16.charge_id = 555
+
+        await device_ocpp_j16.action_meter_value({"connectorId": 1}, meter_value=100)
+
+        assert captured["MeterValues"]["transactionId"] == 555
+
+    @pytest.mark.asyncio
+    async def test_no_stale_transaction_id_after_completed_session(self, device_ocpp_j16, no_sleep):
+        """A completed charge must not leave its id attached to later idle
+        meter values."""
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append((action, payload))
+            if action == "StartTransaction":
+                return _stub_start_transaction_response()
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        assert await device_ocpp_j16.flow_charge(True, {
+            "connectorId": 1, "idTag": "X",
+            "autoActionsLoopDelayInSeconds": 0, "autoActionsLoopCount": 1,
+        }) is True
+        in_charge = [p for a, p in sent if a == "MeterValues"]
+        assert all(p["transactionId"] == 555 for p in in_charge)
+
+        sent.clear()
+        await device_ocpp_j16.action_meter_value({"connectorId": 1}, meter_value=100)
+
+        assert "transactionId" not in sent[0][1]
+
 
 class TestJ16StopTransactionPayload:
     async def _capture_stop(self, device, options):

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -516,6 +516,40 @@ class TestJ16ScriptedMeterValuesFlow:
         assert second_start["meterStart"] == 1000
         assert second_stop["meterStop"] == 2000
 
+    @pytest.mark.asyncio
+    async def test_stop_reports_last_delivered_sample_when_a_send_fails_mid_script(self, device_ocpp_j16, no_sleep):
+        """A MeterValues send failure aborts the script; the stop must repeat
+        the last sample the backend actually received, not the configured
+        final value the session never reached."""
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append((action, payload))
+            if action == "StartTransaction":
+                return _stub_start_transaction_response()
+            if (action == "MeterValues"
+                    and payload["meterValue"][0]["sampledValue"][0]["value"] == "10000"):
+                return None
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+        options = {
+            "connectorId": 1, "idTag": "X", "meterStart": 1000,
+            "meterValues": [
+                {"meterValue": 1500, "timestamp": "2025-01-15T12:10:00+00:00",
+                 "secondsToSleep": 0},
+                {"meterValue": 10000, "timestamp": "2025-01-15T12:20:00+00:00",
+                 "secondsToSleep": 0},
+            ],
+        }
+
+        ok = await device_ocpp_j16.flow_charge(True, options)
+
+        assert ok is False
+        stop = [p for a, p in sent if a == "StopTransaction"][0]
+        assert stop["meterStop"] == 1500
+        assert stop["transactionData"][0]["sampledValue"][0]["value"] == "1500"
+
 
 class TestJ16FlowReserveStatusPayload:
     @pytest.mark.asyncio

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -17,8 +17,8 @@ def _stub_authorize_response(id_tag: str, parent_id_tag: str = None):
     return [3, "req-1", {"idTagInfo": info}]
 
 
-def _stub_start_transaction_response(transaction_id: int = 555):
-    return [3, "req-1", {"idTagInfo": {"status": "Accepted"}, "transactionId": transaction_id}]
+def _stub_start_transaction_response(transaction_id: int = 555, status: str = "Accepted"):
+    return [3, "req-1", {"idTagInfo": {"status": status}, "transactionId": transaction_id}]
 
 
 def _seed_reservation(device, *, reservation_id=42, connector_id=1,
@@ -315,6 +315,37 @@ class TestJ16MidFlowFailureStillStops:
 
         assert ok is False
         assert "StopTransaction" not in actions
+
+
+class TestJ16RejectedStartRollsBackStatus:
+    """Preparing is sent before StartTransaction; if the CSMS then rejects the
+    start (e.g. the tag turned Blocked between Authorize and start), the flow
+    must send Available so the connector isn't left stuck in Preparing."""
+
+    @pytest.mark.asyncio
+    async def test_blocked_start_sends_available_after_preparing(self, device_ocpp_j16, no_sleep):
+        device_ocpp_j16.error_exit = False
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append((action, payload))
+            if action == "StartTransaction":
+                return _stub_start_transaction_response(status="Blocked")
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        ok = await device_ocpp_j16.flow_charge(True, {
+            "connectorId": 1, "idTag": "X",
+            "autoActionsLoopDelayInSeconds": 0, "autoActionsLoopCount": 1,
+        })
+
+        assert ok is False
+        statuses = [p.get("status") for a, p in sent if a == "StatusNotification"]
+        assert statuses == ["Preparing", "Available"]
+        # No transaction was ever opened, so nothing to stop
+        assert "StopTransaction" not in [a for a, _ in sent]
+        assert device_ocpp_j16.charge_in_progress is False
 
 
 class TestJ16ScriptedMeterValuesFlow:

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -1,6 +1,13 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
+
+
+@pytest.fixture
+def no_sleep():
+    """flow_charge waits out a fixed cool-down after the meter loop; skip it."""
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        yield
 
 
 def _stub_authorize_response(id_tag: str, parent_id_tag: str = None):
@@ -120,6 +127,48 @@ class TestJ16FlowChargeReservationGate:
         assert "StatusNotification" not in sent
         # Reservation preserved
         assert device_ocpp_j16.reservation_is_active()
+
+
+class TestJ16ChargeCycleIsolation:
+    """The regression behind Virta sessions staying CLOSED: consecutive
+    frequent-flow charges shared one options dict, so every cycle after the
+    first replayed the first cycle's start time and meterStop."""
+
+    @pytest.mark.asyncio
+    async def test_second_cycle_sends_fresh_start_and_stop(self, device_ocpp_j16, no_sleep):
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append((action, payload))
+            if action == "StartTransaction":
+                return _stub_start_transaction_response()
+            return [3, "req-1", {"idTagInfo": {"status": "Accepted"}}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+        # Shared dict, exactly as Simulator.loop_flow_frequent passes it
+        options = {
+            "connectorId": 1,
+            "idTag": "X",
+            "autoActionsLoopDelayInSeconds": 0,
+            "autoActionsLoopCount": 1,
+        }
+
+        await device_ocpp_j16.flow_charge(True, options)
+        first_start = [p for a, p in sent if a == "StartTransaction"][0]
+        first_stop = [p for a, p in sent if a == "StopTransaction"][0]
+
+        sent.clear()
+        await device_ocpp_j16.flow_charge(True, options)
+        second_start = [p for a, p in sent if a == "StartTransaction"][0]
+        second_stop = [p for a, p in sent if a == "StopTransaction"][0]
+
+        # Each cycle declares its own time window
+        assert second_start["timestamp"] != first_start["timestamp"]
+        assert second_stop["timestamp"] != first_stop["timestamp"]
+        # The second cycle starts where the first stopped — a real energy
+        # register never rewinds
+        assert second_start["meterStart"] == first_stop["meterStop"]
+        assert second_stop["meterStop"] >= second_start["meterStart"]
 
 
 class TestJ16FlowReserveStatusPayload:

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -146,6 +146,24 @@ class TestJ16MeterValuesPayload:
         sampled = captured["MeterValues"]["meterValue"][0]["sampledValue"][0]
         assert sampled["value"] == "2500"
 
+    @pytest.mark.asyncio
+    async def test_explicit_zero_reading_is_sent_as_zero(self, device_ocpp_j16):
+        """0 is a legitimate register reading (fresh/reset meter); a falsy
+        check replaced it with a computed value, fabricating data that
+        contradicts the operator's script."""
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return [3, "req-1", {}]
+
+        device_ocpp_j16.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        await device_ocpp_j16.action_meter_value({"connectorId": 1}, meter_value=0)
+
+        sampled = captured["MeterValues"]["meterValue"][0]["sampledValue"][0]
+        assert sampled["value"] == "0"
+
 
 class TestJ16StopTransactionPayload:
     async def _capture_stop(self, device, options):

--- a/tests/test_device_ocpp_j16.py
+++ b/tests/test_device_ocpp_j16.py
@@ -299,6 +299,8 @@ class TestJ16StopTransactionConfHandling:
 
     @pytest.mark.asyncio
     async def test_timeout_or_call_error_still_fails(self, device_ocpp_j16):
+        """The id must clear even when the conf never arrives — there is no
+        retry path, and a kept id would re-attach to later idle MeterValues."""
         device_ocpp_j16.error_exit = False
         device_ocpp_j16.charge_id = 555
         device_ocpp_j16.by_device_req_send = AsyncMock(return_value=None)
@@ -306,16 +308,18 @@ class TestJ16StopTransactionConfHandling:
         ok = await device_ocpp_j16.action_charge_stop(self._options())
 
         assert ok is False
-        assert device_ocpp_j16.charge_id == 555
+        assert device_ocpp_j16.charge_id == -1
 
     @pytest.mark.asyncio
     async def test_malformed_conf_still_fails(self, device_ocpp_j16):
         device_ocpp_j16.error_exit = False
+        device_ocpp_j16.charge_id = 555
         device_ocpp_j16.by_device_req_send = AsyncMock(return_value=[3, "r"])
 
         ok = await device_ocpp_j16.action_charge_stop(self._options())
 
         assert ok is False
+        assert device_ocpp_j16.charge_id == -1
 
 
 class TestJ16ChargeCycleIsolation:

--- a/tests/test_device_ocpp_j201.py
+++ b/tests/test_device_ocpp_j201.py
@@ -1,6 +1,13 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
+
+
+@pytest.fixture
+def no_sleep():
+    """flow_charge waits out a fixed cool-down after the meter loop; skip it."""
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        yield
 
 
 def _stub_authorize_response(id_tag: str, group_id_tag: str = None):
@@ -169,26 +176,88 @@ class TestJ201TransactionEventEndedConfHandling:
 
     @pytest.mark.asyncio
     async def test_empty_response_is_a_successful_stop(self, device_ocpp_j201):
+        device_ocpp_j201.charge_id = "txn-1"
         device_ocpp_j201.by_device_req_send = AsyncMock(return_value=[3, "r", {}])
 
         ok = await device_ocpp_j201.action_charge_stop(self._options())
 
         assert ok is True
+        assert device_ocpp_j201.charge_id == -1
 
     @pytest.mark.asyncio
     async def test_non_accepted_id_token_info_still_stops(self, device_ocpp_j201):
+        device_ocpp_j201.charge_id = "txn-1"
         device_ocpp_j201.by_device_req_send = AsyncMock(
             return_value=[3, "r", {"idTokenInfo": {"status": "Blocked"}}])
 
         ok = await device_ocpp_j201.action_charge_stop(self._options())
 
         assert ok is True
+        assert device_ocpp_j201.charge_id == -1
 
     @pytest.mark.asyncio
     async def test_timeout_or_call_error_still_fails(self, device_ocpp_j201):
+        """The id must clear even when the response never arrives — there is
+        no retry path, and a kept UUID would replay into later triggered
+        meter values."""
         device_ocpp_j201.error_exit = False
+        device_ocpp_j201.charge_id = "txn-1"
         device_ocpp_j201.by_device_req_send = AsyncMock(return_value=None)
 
         ok = await device_ocpp_j201.action_charge_stop(self._options())
 
         assert ok is False
+        assert device_ocpp_j201.charge_id == -1
+
+
+class TestJ201NoStaleTransactionId:
+    """TransactionEvent Updated must reference an open transaction. Before the
+    charge_id reset, a triggered MeterValues after a completed session sent an
+    Updated event carrying the previous transaction's UUID."""
+
+    @pytest.mark.asyncio
+    async def test_idle_meter_value_sends_nothing(self, device_ocpp_j201):
+        device_ocpp_j201.by_device_req_send = AsyncMock()
+
+        ok = await device_ocpp_j201.action_meter_value({"connectorId": 1}, meter_value=100)
+
+        assert ok is True
+        device_ocpp_j201.by_device_req_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_meter_value_during_transaction_still_sends(self, device_ocpp_j201):
+        captured = {}
+
+        async def fake_send(action, payload):
+            captured[action] = payload
+            return [3, "r", {}]
+
+        device_ocpp_j201.by_device_req_send = AsyncMock(side_effect=fake_send)
+        device_ocpp_j201.charge_id = "txn-1"
+
+        ok = await device_ocpp_j201.action_meter_value({"connectorId": 1}, meter_value=100)
+
+        assert ok is True
+        assert captured["TransactionEvent"]["transactionInfo"]["transactionId"] == "txn-1"
+
+    @pytest.mark.asyncio
+    async def test_no_stale_transaction_id_after_completed_session(
+            self, device_ocpp_j201, no_sleep):
+        sent = []
+
+        async def fake_send(action, payload):
+            sent.append((action, payload))
+            return [3, "req-1", {"idTokenInfo": {"status": "Accepted"}}]
+
+        device_ocpp_j201.by_device_req_send = AsyncMock(side_effect=fake_send)
+
+        assert await device_ocpp_j201.flow_charge(True, {
+            "connectorId": 1, "idTag": "X",
+            "autoActionsLoopDelayInSeconds": 0, "autoActionsLoopCount": 1,
+        }) is True
+        assert device_ocpp_j201.charge_id == -1
+
+        sent.clear()
+        await device_ocpp_j201.action_meter_value({"connectorId": 1}, meter_value=100)
+
+        assert sent == []

--- a/tests/test_device_ocpp_j201.py
+++ b/tests/test_device_ocpp_j201.py
@@ -156,3 +156,39 @@ class TestJ201FlowReserveStatusPayload:
         assert ok is True
         assert captured["StatusNotification"]["connectorStatus"] == "Reserved"
         assert captured["StatusNotification"]["evseId"] == 1
+
+
+class TestJ201TransactionEventEndedConfHandling:
+    """idTokenInfo is optional in TransactionEventResponse and concerns the
+    token, not whether the Ended event was registered — an empty payload is
+    the common success response and used to raise KeyError."""
+
+    def _options(self):
+        return {"connectorId": 1, "idTag": "X", "meterStart": 1000,
+                "meterStop": 2000, "chargeStopTime": "2025-01-15T12:30:00+00:00"}
+
+    @pytest.mark.asyncio
+    async def test_empty_response_is_a_successful_stop(self, device_ocpp_j201):
+        device_ocpp_j201.by_device_req_send = AsyncMock(return_value=[3, "r", {}])
+
+        ok = await device_ocpp_j201.action_charge_stop(self._options())
+
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_non_accepted_id_token_info_still_stops(self, device_ocpp_j201):
+        device_ocpp_j201.by_device_req_send = AsyncMock(
+            return_value=[3, "r", {"idTokenInfo": {"status": "Blocked"}}])
+
+        ok = await device_ocpp_j201.action_charge_stop(self._options())
+
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_timeout_or_call_error_still_fails(self, device_ocpp_j201):
+        device_ocpp_j201.error_exit = False
+        device_ocpp_j201.by_device_req_send = AsyncMock(return_value=None)
+
+        ok = await device_ocpp_j201.action_charge_stop(self._options())
+
+        assert ok is False

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -183,27 +183,6 @@ class TestErrorExitInteractiveBehavior:
         # still crash on rejected responses (the existing fail-fast behavior).
         assert mock_device.error_exit is True
 
-    @pytest.mark.asyncio
-    async def test_lifecycle_start_flips_interactive_mode(
-            self, simulator, mock_device):
-        mock_device.interactive_mode = False
-        simulator.is_interactive = True
-        simulator.frequent_flow_enabled = False
-        with patch.object(simulator, "loop_interactive", new_callable=AsyncMock):
-            await simulator.lifecycle_start()
-
-        assert mock_device.interactive_mode is True
-
-    @pytest.mark.asyncio
-    async def test_lifecycle_start_leaves_interactive_mode_when_not_interactive(
-            self, simulator, mock_device):
-        mock_device.interactive_mode = False
-        simulator.is_interactive = False
-        simulator.frequent_flow_enabled = False
-
-        await simulator.lifecycle_start()
-
-        assert mock_device.interactive_mode is False
 
 
 class TestSimulatorErrorHandling:


### PR DESCRIPTION
## Note for reviewer
Each commit is a self-contained fix with its own tests and rationale in the message — **reviewing commit by commit is much easier than the combined diff.**

## Problem

Virta reports that simulator sessions stay in `CLOSED` and never reach `COMPLETED`, attributing it to the simulator "not sending costs / prices".

In OCPP 1.6 the charge point never sends prices — the CSMS derives cost from the metering data. So "no costs" means "we cannot compute a price from what the simulator sends". The metering data is genuinely unusable for every session after the first.

## Root cause

`Simulator.loop_flow_frequent` passes the configured `flow_charge_options` dict **by reference** into every charge cycle, and the `fill_missing_options_charge_*` helpers only write keys that are **absent**:

```python
if "chargeStartTime" not in options:
    options["chargeStartTime"] = self.utcnow_iso()
```

So `chargeStartTime`, `chargeStopTime` and `meterStop` are written once on the first cycle and then replayed forever. Meanwhile the periodic `MeterValues` **are** recomputed live (`charge_meter_value_current` derives from wall-clock time), so they keep climbing.

A per-cycle reset for this already existed (added in `26d8990`) but was gated on `interactive_mode`, which is only ever set for interactive sessions — so it never ran in the deployed frequent-flow mode. Its docstring claimed frequent-flow runs "construct their own options each loop iteration"; nothing in the loop does that.

### Evidence

Two consecutive frequent-flow charge cycles driven through `flow_charge` against a mocked transport, with one shared options dict — exactly how `Simulator.loop_flow_frequent` calls it. Both traces below are **verbatim stdout from the same script**, run once against `master` and once against this branch.

The script only observes and never asserts, so it runs unmodified on both sides. It is reproducible: `scratchpad/wire_trace.py`, invoked as:

```bash
PYTHONPATH=<tree>/src python wire_trace.py
```

This exercises the simulator's own message construction. It does not talk to Virta, so it demonstrates what we put on the wire, not how they react to it.

**Before** (`master`, `8a4e851`):

```text
=== cycle 1 (master, before fix) ===
  Authorize  {'idTag': 'MAPP-SIM-TAG-01'}
  StartTransaction    timestamp=2026-08-12T15:20:05.498795+00:00 connectorId=1 meterStart=1000
  StatusNotification  status=Preparing
  StatusNotification  status=Charging
  MeterValues         timestamp=2026-08-12T15:20:06.500968+00:00 value=2002 (int) unit=Wh
  MeterValues         timestamp=2026-08-12T15:20:07.506223+00:00 value=3007 (int) unit=Wh
  StatusNotification  status=Finishing
  StopTransaction     timestamp=2026-08-12T15:20:12.508065+00:00 meterStop=8009 transactionData=<absent>
  StatusNotification  status=Available
  -> declared window 1000..8009 Wh; meter samples [2002, 3007]; samples inside window: True

=== cycle 2 (master, before fix) ===
  Authorize  {'idTag': 'MAPP-SIM-TAG-01'}
  StartTransaction    timestamp=2026-08-12T15:20:05.498795+00:00 connectorId=1 meterStart=1000
  StatusNotification  status=Preparing
  StatusNotification  status=Charging
  MeterValues         timestamp=2026-08-12T15:20:13.509020+00:00 value=9010 (int) unit=Wh
  MeterValues         timestamp=2026-08-12T15:20:14.510388+00:00 value=10011 (int) unit=Wh
  StatusNotification  status=Finishing
  StopTransaction     timestamp=2026-08-12T15:20:12.508065+00:00 meterStop=8009 transactionData=<absent>
  StatusNotification  status=Available
  -> declared window 1000..8009 Wh; meter samples [9010, 10011]; samples inside window: False

--- across the two cycles ---
  cycle 2 start timestamp differs from cycle 1: False
  cycle 2 stop  timestamp differs from cycle 1: False
  cycle 2 starts where cycle 1 stopped (register continuous): False
```

Cycle 2 is unusable three ways over. It re-declares cycle 1's exact time window, so the two transactions overlap completely. Its meter samples (`9010`, `10011 Wh`) fall outside its own declared `1000 → 8009` range. And its `StopTransaction` timestamp (`15:20:12`) is *earlier* than the `MeterValues` it just sent (`15:20:13`, `15:20:14`) — the session claims to have ended before its own readings were taken.

`StopTransaction` still arrives, so the session closes. But there is no self-consistent energy figure to derive, so it cannot be priced and never advances past `CLOSED`.

**After** (this branch, `483dd02`):

```text
=== cycle 1 (feature/misc-fixes, after fix) ===
  Authorize  {'idTag': 'MAPP-SIM-TAG-01'}
  StatusNotification  status=Preparing
  StartTransaction    timestamp=2026-08-12T15:20:32.252161+00:00 connectorId=1 meterStart=1000
  StatusNotification  status=Charging
  MeterValues         timestamp=2026-08-12T15:20:33.253618+00:00 value='2003' (str) unit=Wh
  MeterValues         timestamp=2026-08-12T15:20:34.258003+00:00 value='3009' (str) unit=Wh
  StatusNotification  status=Finishing
  StopTransaction     timestamp=2026-08-12T15:20:39.264440+00:00 meterStop=8012 transactionData=[Transaction.End '8012']
  StatusNotification  status=Available
  -> declared window 1000..8012 Wh; meter samples [2003, 3009]; samples inside window: True

=== cycle 2 (feature/misc-fixes, after fix) ===
  Authorize  {'idTag': 'MAPP-SIM-TAG-01'}
  StatusNotification  status=Preparing
  StartTransaction    timestamp=2026-08-12T15:20:39.265058+00:00 connectorId=1 meterStart=8012
  StatusNotification  status=Charging
  MeterValues         timestamp=2026-08-12T15:20:40.265872+00:00 value='9012' (str) unit=Wh
  MeterValues         timestamp=2026-08-12T15:20:41.267584+00:00 value='10014' (str) unit=Wh
  StatusNotification  status=Finishing
  StopTransaction     timestamp=2026-08-12T15:20:46.271852+00:00 meterStop=15018 transactionData=[Transaction.End '15018']
  StatusNotification  status=Available
  -> declared window 8012..15018 Wh; meter samples [9012, 10014]; samples inside window: True

--- across the two cycles ---
  cycle 2 start timestamp differs from cycle 1: True
  cycle 2 stop  timestamp differs from cycle 1: True
  cycle 2 starts where cycle 1 stopped (register continuous): True
```

Each cycle now declares its own non-overlapping window, every sample falls inside it, and the register continues across sessions (`8012 → 8012`) instead of resetting.

The `Preparing`-before-`StartTransaction` reordering and the string-typed `value` / `transactionData` additions from `483dd02` are also visible in the diff between the two traces.

## Summary

Fixes for the issue Virta reported: simulator sessions stuck in `CLOSED` (never reaching `COMPLETED`) and occasionally broken costs. Root causes fell into three groups, all on the OCPP-J path:

**Sessions never completing.** An empty `StopTransaction.conf` (`idTagInfo` is optional) crashed the flow after the CSMS had already closed the transaction, and any mid-session failure skipped `StopTransaction` entirely, leaving the session open server-side. The charge flow now always sends the stop once a transaction is open, accepts any valid `CALLRESULT` as a successful stop, and rolls the connector back to `Available` when a start is rejected.

**Broken costs.** Meter values now conform to the 1.6J schema (string `sampledValue.value`), the stop carries a `Transaction.End` sample, explicit zero readings are sent instead of computed ones, `transactionId` is omitted outside a transaction (and cleared after every stop attempt), and per-cycle option resets keep the energy register monotonic across frequent-flow cycles instead of replaying the first cycle's timestamps and `meterStop`.

**Simulator robustness.** `CALLERROR`s and response timeouts are now treated as failed requests (a timeout previously looked like success to `is None` checks), `TriggerMessage` actions are scheduled as tasks instead of being awaited inside the websocket read loop (which could deadlock or kill it), and late replies to timed-out requests no longer crash the reader. Reservation handling got connector-0 support and stops replaying consumed reservation IDs.